### PR TITLE
fix(useTouchEmulation): touchMove will be triggered by mouseMove even mouseDown not called

### DIFF
--- a/.changeset/six-loops-go.md
+++ b/.changeset/six-loops-go.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/react-use': patch
+---
+
+Fix an issue for `useTouchEmulation` that emulated `touchMove` will be triggered by mouseMove, even when mouseDown not called

--- a/.changeset/tangy-crabs-burn.md
+++ b/.changeset/tangy-crabs-burn.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/react-use': patch
+---
+
+Add proper memoization for `usePointerEvent` and `useTouchEmulation`, so reRender will not triggered unintentionally

--- a/src/usePointerEvent.ts
+++ b/src/usePointerEvent.ts
@@ -1,59 +1,66 @@
-import type { MainThread, MouseEvent, Touch, TouchEvent } from '@lynx-js/types'
+import { useMemo } from '@lynx-js/react';
+import type { MainThread, MouseEvent, Touch, TouchEvent } from '@lynx-js/types';
 
-type PointerAction = 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel'
+type PointerAction =
+  | 'pointerdown'
+  | 'pointermove'
+  | 'pointerup'
+  | 'pointercancel';
 
 interface CustomPointerEvent {
-  type: PointerAction
-  pointerType: 'mouse' | 'touch'
-  x: number
-  y: number
-  pointerId: number
-  isPrimary: boolean
-  pageX?: number
-  pageY?: number
-  clientX?: number
-  clientY?: number
-  button?: number
-  buttons?: number
-  identifier?: number
-  originalEvent: unknown
+  type: PointerAction;
+  pointerType: 'mouse' | 'touch';
+  x: number;
+  y: number;
+  pointerId: number;
+  isPrimary: boolean;
+  pageX?: number;
+  pageY?: number;
+  clientX?: number;
+  clientY?: number;
+  button?: number;
+  buttons?: number;
+  identifier?: number;
+  originalEvent: unknown;
 }
 
 interface UsePointerEventReturn {
-  bindmousedown?: (e: MouseEvent) => void
-  bindtouchstart?: (e: TouchEvent) => void
-  bindmousemove?: (e: MouseEvent) => void
-  bindtouchmove?: (e: TouchEvent) => void
-  bindmouseup?: (e: MouseEvent) => void
-  bindtouchend?: (e: TouchEvent) => void
-  bindtouchcancel?: (e: TouchEvent) => void
-  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void
-  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void
-  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void
-  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void
-  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void
-  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void
-  'main-thread:bindtouchcancel'?: (e: MainThread.TouchEvent) => void
+  bindmousedown?: (e: MouseEvent) => void;
+  bindtouchstart?: (e: TouchEvent) => void;
+  bindmousemove?: (e: MouseEvent) => void;
+  bindtouchmove?: (e: TouchEvent) => void;
+  bindmouseup?: (e: MouseEvent) => void;
+  bindtouchend?: (e: TouchEvent) => void;
+  bindtouchcancel?: (e: TouchEvent) => void;
+  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
+  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
+  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
+  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
+  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
+  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
+  'main-thread:bindtouchcancel'?: (e: MainThread.TouchEvent) => void;
 }
 
 interface CustomPointerEventMT extends CustomPointerEvent {
-  target: MainThread.Element
-  currentTarget: MainThread.Element
-  originalEvent: MainThread.MouseEvent | MainThread.TouchEvent
+  target: MainThread.Element;
+  currentTarget: MainThread.Element;
+  originalEvent: MainThread.MouseEvent | MainThread.TouchEvent;
 }
 
 function unifyPointerEvent(
   event: MouseEvent | TouchEvent,
   type: PointerAction,
 ): CustomPointerEvent {
-  const isTouch = 'detail' in event
+  'background only';
+  const isTouch = 'touches' in (event as unknown as Record<string, unknown>)
+    || 'changedTouches' in (event as unknown as Record<string, unknown>);
   if (isTouch) {
-    const te = event as TouchEvent
-    const t: Touch | undefined = te.touches?.[0] ?? te.changedTouches?.[0]
-    const pointerId = t?.identifier ?? 0
-    const touchesLen = te.touches?.length ?? 0
-    const primaryId = te.touches?.[0]?.identifier
-    const isPrimary = touchesLen <= 1 || pointerId === primaryId
+    const te = event as TouchEvent;
+    const t: Touch | undefined = te.touches?.[0] ?? te.changedTouches?.[0];
+    const pointerId = t?.identifier ?? 0;
+    const touchesLen = te.touches?.length ?? 0;
+    const primaryId = te.touches?.[0]?.identifier;
+    const isPrimary = touchesLen <= 1 || pointerId === primaryId;
     return {
       type,
       pointerType: 'touch',
@@ -66,16 +73,16 @@ function unifyPointerEvent(
       clientX: t?.clientX,
       clientY: t?.clientY,
       originalEvent: event,
-    }
+    };
   }
-  const mouse = event as MouseEvent
+  const mouse = event as MouseEvent;
   const mapButton = (b?: number): number | undefined => {
-    if (b == null) return undefined
-    if (b === 1) return 0
-    if (b === 2) return 2
-    if (b === 3) return 1
-    return b
-  }
+    if (b == null) return undefined;
+    if (b === 1) return 0;
+    if (b === 2) return 2;
+    if (b === 3) return 1;
+    return b;
+  };
   return {
     type,
     pointerType: 'mouse',
@@ -90,22 +97,23 @@ function unifyPointerEvent(
     button: mapButton(mouse.button),
     buttons: mouse.buttons,
     originalEvent: mouse,
-  }
+  };
 }
 
 function unifyPointerEventMT(
   event: MainThread.MouseEvent | MainThread.TouchEvent,
   type: PointerAction,
 ): CustomPointerEventMT {
-  'main thread'
-  const isTouch = 'detail' in event
+  'main thread';
+  const isTouch = 'touches' in (event as unknown as Record<string, unknown>)
+    || 'changedTouches' in (event as unknown as Record<string, unknown>);
   if (isTouch) {
-    const te = event as MainThread.TouchEvent
-    const t: Touch | undefined = te.touches?.[0] ?? te.changedTouches?.[0]
-    const pointerId = t?.identifier ?? 0
-    const touchesLen = te.touches?.length ?? 0
-    const primaryId = te.touches?.[0]?.identifier
-    const isPrimary = touchesLen <= 1 || pointerId === primaryId
+    const te = event as MainThread.TouchEvent;
+    const t: Touch | undefined = te.touches?.[0] ?? te.changedTouches?.[0];
+    const pointerId = t?.identifier ?? 0;
+    const touchesLen = te.touches?.length ?? 0;
+    const primaryId = te.touches?.[0]?.identifier;
+    const isPrimary = touchesLen <= 1 || pointerId === primaryId;
     return {
       type,
       pointerType: 'touch',
@@ -120,16 +128,16 @@ function unifyPointerEventMT(
       target: event.target,
       currentTarget: event.currentTarget,
       originalEvent: event,
-    }
+    };
   }
-  const mouse = event as MainThread.MouseEvent
+  const mouse = event as MainThread.MouseEvent;
   const mapButton = (b?: number): number | undefined => {
-    if (b == null) return undefined
-    if (b === 1) return 0
-    if (b === 2) return 2
-    if (b === 3) return 1
-    return b
-  }
+    if (b == null) return undefined;
+    if (b === 1) return 0;
+    if (b === 2) return 2;
+    if (b === 3) return 1;
+    return b;
+  };
   return {
     type,
     pointerType: 'mouse',
@@ -146,7 +154,7 @@ function unifyPointerEventMT(
     target: mouse.target,
     currentTarget: mouse.currentTarget,
     originalEvent: mouse,
-  }
+  };
 }
 
 // BG helpers are inlined inside unifyPointerEvent for parity with MT
@@ -165,92 +173,112 @@ function usePointerEvent({
   onPointerDownMT,
   onPointerCancelMT,
 }: {
-  onPointerDown?: (event: CustomPointerEvent) => void
-  onPointerUp?: (event: CustomPointerEvent) => void
-  onPointerMove?: (event: CustomPointerEvent) => void
-  onPointerCancel?: (event: CustomPointerEvent) => void
-  onPointerUpMT?: (event: CustomPointerEventMT) => void
-  onPointerMoveMT?: (event: CustomPointerEventMT) => void
-  onPointerDownMT?: (event: CustomPointerEventMT) => void
-  onPointerCancelMT?: (event: CustomPointerEventMT) => void
+  onPointerDown?: (event: CustomPointerEvent) => void;
+  onPointerUp?: (event: CustomPointerEvent) => void;
+  onPointerMove?: (event: CustomPointerEvent) => void;
+  onPointerCancel?: (event: CustomPointerEvent) => void;
+  onPointerUpMT?: (event: CustomPointerEventMT) => void;
+  onPointerMoveMT?: (event: CustomPointerEventMT) => void;
+  onPointerDownMT?: (event: CustomPointerEventMT) => void;
+  onPointerCancelMT?: (event: CustomPointerEventMT) => void;
 }): UsePointerEventReturn {
-  const result: UsePointerEventReturn = {}
+  const result = useMemo<UsePointerEventReturn>(() => {
+    const r: UsePointerEventReturn = {};
 
-  if (onPointerDown) {
-    result.bindmousedown = (event: MouseEvent) => {
-      onPointerDown(unifyPointerEvent(event, 'pointerdown'))
+    if (onPointerDown) {
+      r.bindmousedown = (event: MouseEvent) => {
+        'background only';
+        onPointerDown(unifyPointerEvent(event, 'pointerdown'));
+      };
+      r.bindtouchstart = (event: TouchEvent) => {
+        'background only';
+        onPointerDown(unifyPointerEvent(event, 'pointerdown'));
+      };
     }
-    result.bindtouchstart = (event: TouchEvent) => {
-      onPointerDown(unifyPointerEvent(event, 'pointerdown'))
-    }
-  }
 
-  if (onPointerMove) {
-    result.bindmousemove = (event: MouseEvent) => {
-      onPointerMove(unifyPointerEvent(event, 'pointermove'))
+    if (onPointerMove) {
+      r.bindmousemove = (event: MouseEvent) => {
+        'background only';
+        onPointerMove(unifyPointerEvent(event, 'pointermove'));
+      };
+      r.bindtouchmove = (event: TouchEvent) => {
+        'background only';
+        onPointerMove(unifyPointerEvent(event, 'pointermove'));
+      };
     }
-    result.bindtouchmove = (event: TouchEvent) => {
-      onPointerMove(unifyPointerEvent(event, 'pointermove'))
-    }
-  }
 
-  if (onPointerUp) {
-    result.bindmouseup = (event: MouseEvent) => {
-      onPointerUp(unifyPointerEvent(event, 'pointerup'))
+    if (onPointerUp) {
+      r.bindmouseup = (event: MouseEvent) => {
+        'background only';
+        onPointerUp(unifyPointerEvent(event, 'pointerup'));
+      };
+      r.bindtouchend = (event: TouchEvent) => {
+        'background only';
+        onPointerUp(unifyPointerEvent(event, 'pointerup'));
+      };
     }
-    result.bindtouchend = (event: TouchEvent) => {
-      onPointerUp(unifyPointerEvent(event, 'pointerup'))
-    }
-  }
 
-  if (onPointerCancel) {
-    result.bindtouchcancel = (event: TouchEvent) => {
-      onPointerCancel(unifyPointerEvent(event, 'pointercancel'))
+    if (onPointerCancel) {
+      r.bindtouchcancel = (event: TouchEvent) => {
+        'background only';
+        onPointerCancel(unifyPointerEvent(event, 'pointercancel'));
+      };
     }
-  }
 
-  if (onPointerDownMT) {
-    result['main-thread:bindmousedown'] = (event: MainThread.MouseEvent) => {
-      'main thread'
-      onPointerDownMT(unifyPointerEventMT(event, 'pointerdown'))
+    if (onPointerDownMT) {
+      r['main-thread:bindmousedown'] = (event: MainThread.MouseEvent) => {
+        'main thread';
+        onPointerDownMT(unifyPointerEventMT(event, 'pointerdown'));
+      };
+      r['main-thread:bindtouchstart'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onPointerDownMT(unifyPointerEventMT(event, 'pointerdown'));
+      };
     }
-    result['main-thread:bindtouchstart'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onPointerDownMT(unifyPointerEventMT(event, 'pointerdown'))
-    }
-  }
 
-  if (onPointerMoveMT) {
-    result['main-thread:bindmousemove'] = (event: MainThread.MouseEvent) => {
-      'main thread'
-      onPointerMoveMT(unifyPointerEventMT(event, 'pointermove'))
+    if (onPointerMoveMT) {
+      r['main-thread:bindmousemove'] = (event: MainThread.MouseEvent) => {
+        'main thread';
+        onPointerMoveMT(unifyPointerEventMT(event, 'pointermove'));
+      };
+      r['main-thread:bindtouchmove'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onPointerMoveMT(unifyPointerEventMT(event, 'pointermove'));
+      };
     }
-    result['main-thread:bindtouchmove'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onPointerMoveMT(unifyPointerEventMT(event, 'pointermove'))
-    }
-  }
 
-  if (onPointerUpMT) {
-    result['main-thread:bindmouseup'] = (event: MainThread.MouseEvent) => {
-      'main thread'
-      onPointerUpMT(unifyPointerEventMT(event, 'pointerup'))
+    if (onPointerUpMT) {
+      r['main-thread:bindmouseup'] = (event: MainThread.MouseEvent) => {
+        'main thread';
+        onPointerUpMT(unifyPointerEventMT(event, 'pointerup'));
+      };
+      r['main-thread:bindtouchend'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onPointerUpMT(unifyPointerEventMT(event, 'pointerup'));
+      };
     }
-    result['main-thread:bindtouchend'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onPointerUpMT(unifyPointerEventMT(event, 'pointerup'))
-    }
-  }
 
-  if (onPointerCancelMT) {
-    result['main-thread:bindtouchcancel'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onPointerCancelMT(unifyPointerEventMT(event, 'pointercancel'))
+    if (onPointerCancelMT) {
+      r['main-thread:bindtouchcancel'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onPointerCancelMT(unifyPointerEventMT(event, 'pointercancel'));
+      };
     }
-  }
 
-  return result
+    return r;
+  }, [
+    onPointerDown,
+    onPointerUp,
+    onPointerMove,
+    onPointerCancel,
+    onPointerUpMT,
+    onPointerMoveMT,
+    onPointerDownMT,
+    onPointerCancelMT,
+  ]);
+
+  return result;
 }
 
-export default usePointerEvent
-export type { CustomPointerEvent, CustomPointerEventMT }
+export default usePointerEvent;
+export type { CustomPointerEvent, CustomPointerEventMT };

--- a/src/useTouchEmulation.ts
+++ b/src/useTouchEmulation.ts
@@ -1,71 +1,75 @@
-import type { MainThread, MouseEvent, Touch, TouchEvent } from '@lynx-js/types'
+import { useMemo } from '@lynx-js/react';
+import type { MainThread, MouseEvent, Touch, TouchEvent } from '@lynx-js/types';
 
-type TouchAction = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel'
+type TouchAction = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 
 interface UseTouchEmulationReturn {
-  bindtouchstart?: (e: TouchEvent) => void
-  bindmousedown?: (e: MouseEvent) => void
-  bindtouchmove?: (e: TouchEvent) => void
-  bindmousemove?: (e: MouseEvent) => void
-  bindtouchend?: (e: TouchEvent) => void
-  bindtouchcancel?: (e: TouchEvent) => void
-  bindmouseup?: (e: MouseEvent) => void
-  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void
-  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void
-  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void
-  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void
-  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void
-  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void
-  'main-thread:bindtouchcancel'?: (e: MainThread.TouchEvent) => void
+  bindtouchstart?: (e: TouchEvent) => void;
+  bindmousedown?: (e: MouseEvent) => void;
+  bindtouchmove?: (e: TouchEvent) => void;
+  bindmousemove?: (e: MouseEvent) => void;
+  bindtouchend?: (e: TouchEvent) => void;
+  bindtouchcancel?: (e: TouchEvent) => void;
+  bindmouseup?: (e: MouseEvent) => void;
+  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
+  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
+  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
+  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
+  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
+  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
+  'main-thread:bindtouchcancel'?: (e: MainThread.TouchEvent) => void;
 }
 
 function toTouchEvent(
   event: MouseEvent | TouchEvent,
   type: TouchAction,
 ): TouchEvent {
-  const isTouch = 'detail' in event
-  if (isTouch) return event as TouchEvent
-  const mouse = event as MouseEvent
+  'background only';
+  const isTouch = 'touches' in (event as unknown as Record<string, unknown>)
+    || 'changedTouches' in (event as unknown as Record<string, unknown>);
+  if (isTouch) return event as TouchEvent;
+  const mouse = event as MouseEvent;
   const touch = {
     identifier: 1,
     pageX: mouse.pageX,
     pageY: mouse.pageY,
     clientX: mouse.clientX,
     clientY: mouse.clientY,
-  } as unknown as Touch
-  const touches = type === 'touchend' ? [] : [touch]
-  const changedTouches = [touch]
+  } as unknown as Touch;
+  const touches = type === 'touchend' ? [] : [touch];
+  const changedTouches = [touch];
   return {
     detail: { x: mouse.pageX, y: mouse.pageY },
     touches,
     changedTouches,
-  } as unknown as TouchEvent
+  } as unknown as TouchEvent;
 }
 
 function toTouchEventMT(
   event: MainThread.MouseEvent | MainThread.TouchEvent,
   type: TouchAction,
 ): MainThread.TouchEvent {
-  'main thread'
-  const isTouch = 'detail' in event
-  if (isTouch) return event as MainThread.TouchEvent
-  const mouse = event as MainThread.MouseEvent
+  'main thread';
+  const isTouch = 'touches' in (event as unknown as Record<string, unknown>)
+    || 'changedTouches' in (event as unknown as Record<string, unknown>);
+  if (isTouch) return event as MainThread.TouchEvent;
+  const mouse = event as MainThread.MouseEvent;
   const touch = {
     identifier: 1,
     pageX: mouse.pageX,
     pageY: mouse.pageY,
     clientX: mouse.clientX,
     clientY: mouse.clientY,
-  } as unknown as Touch
-  const touches = type === 'touchend' ? [] : [touch]
-  const changedTouches = [touch]
+  } as unknown as Touch;
+  const touches = type === 'touchend' ? [] : [touch];
+  const changedTouches = [touch];
   return {
     detail: { x: mouse.pageX, y: mouse.pageY },
     touches,
     changedTouches,
     target: mouse.target,
     currentTarget: mouse.currentTarget,
-  } as unknown as MainThread.TouchEvent
+  } as unknown as MainThread.TouchEvent;
 }
 
 function useTouchEmulation({
@@ -78,91 +82,118 @@ function useTouchEmulation({
   onTouchEndMT,
   onTouchCancelMT,
 }: {
-  onTouchStart?: (event: TouchEvent) => void
-  onTouchMove?: (event: TouchEvent) => void
-  onTouchEnd?: (event: TouchEvent) => void
-  onTouchCancel?: (event: TouchEvent) => void
-  onTouchStartMT?: (event: MainThread.TouchEvent) => void
-  onTouchMoveMT?: (event: MainThread.TouchEvent) => void
-  onTouchEndMT?: (event: MainThread.TouchEvent) => void
-  onTouchCancelMT?: (event: MainThread.TouchEvent) => void
+  onTouchStart?: (event: TouchEvent) => void;
+  onTouchMove?: (event: TouchEvent) => void;
+  onTouchEnd?: (event: TouchEvent) => void;
+  onTouchCancel?: (event: TouchEvent) => void;
+  onTouchStartMT?: (event: MainThread.TouchEvent) => void;
+  onTouchMoveMT?: (event: MainThread.TouchEvent) => void;
+  onTouchEndMT?: (event: MainThread.TouchEvent) => void;
+  onTouchCancelMT?: (event: MainThread.TouchEvent) => void;
 }): UseTouchEmulationReturn {
-  const result: UseTouchEmulationReturn = {}
+  const result = useMemo<UseTouchEmulationReturn>(() => {
+    const r: UseTouchEmulationReturn = {};
 
-  if (onTouchStart) {
-    result.bindtouchstart = (event: TouchEvent) => {
-      onTouchStart(toTouchEvent(event, 'touchstart'))
+    if (onTouchStart) {
+      r.bindtouchstart = (event: TouchEvent) => {
+        'background only';
+        onTouchStart(toTouchEvent(event, 'touchstart'));
+      };
+      r.bindmousedown = (event: MouseEvent) => {
+        'background only'
+        onTouchStart(toTouchEvent(event, 'touchstart'));
+      };
     }
-    result.bindmousedown = (event: MouseEvent) => {
-      onTouchStart(toTouchEvent(event, 'touchstart'))
-    }
-  }
 
-  if (onTouchMove) {
-    result.bindtouchmove = (event: TouchEvent) => {
-      onTouchMove(toTouchEvent(event, 'touchmove'))
+    if (onTouchMove) {
+      r.bindtouchmove = (event: TouchEvent) => {
+        'background only';
+        onTouchMove(toTouchEvent(event, 'touchmove'));
+      };
+      r.bindmousemove = (event: MouseEvent) => {
+        'background only';
+        const buttons = (event as unknown as { buttons?: number }).buttons;
+        // Allow only left-button drags
+        if (!buttons || (buttons & 1) === 0) return;
+        onTouchMove(toTouchEvent(event, 'touchmove'));
+      };
     }
-    result.bindmousemove = (event: MouseEvent) => {
-      onTouchMove(toTouchEvent(event, 'touchmove'))
-    }
-  }
 
-  if (onTouchEnd) {
-    result.bindtouchend = (event: TouchEvent) => {
-      onTouchEnd(toTouchEvent(event, 'touchend'))
+    if (onTouchEnd) {
+      r.bindtouchend = (event: TouchEvent) => {
+        'background only';
+        onTouchEnd(toTouchEvent(event, 'touchend'));
+      };
+      r.bindmouseup = (event: MouseEvent) => {
+        'background only';
+        onTouchEnd(toTouchEvent(event, 'touchend'));
+      };
     }
-    result.bindmouseup = (event: MouseEvent) => {
-      onTouchEnd(toTouchEvent(event, 'touchend'))
-    }
-  }
 
-  if (onTouchCancel) {
-    result.bindtouchend = (event: TouchEvent) => {
-      onTouchCancel(toTouchEvent(event, 'touchcancel'))
+    if (onTouchCancel) {
+      r.bindtouchcancel = (event: TouchEvent) => {
+        'background only';
+        onTouchCancel(toTouchEvent(event, 'touchcancel'));
+      };
     }
-  }
 
-  if (onTouchStartMT) {
-    result['main-thread:bindtouchstart'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onTouchStartMT(toTouchEventMT(event, 'touchstart'))
-    }
-    result['main-thread:bindmousedown'] = (event: MainThread.MouseEvent) => {
-      'main thread'
-      onTouchStartMT(toTouchEventMT(event, 'touchstart'))
-    }
-  }
+    if (onTouchStartMT) {
+      r['main-thread:bindtouchstart'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onTouchStartMT(toTouchEventMT(event, 'touchstart'));
+      };
 
-  if (onTouchMoveMT) {
-    result['main-thread:bindtouchmove'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onTouchMoveMT(toTouchEventMT(event, 'touchmove'))
+      r['main-thread:bindmousedown'] = (event: MainThread.MouseEvent) => {
+        'main thread';
+        onTouchStartMT(toTouchEventMT(event, 'touchstart'));
+      };
     }
-    result['main-thread:bindmousemove'] = (event: MainThread.MouseEvent) => {
-      'main thread'
-      onTouchMoveMT(toTouchEventMT(event, 'touchmove'))
-    }
-  }
 
-  if (onTouchEndMT) {
-    result['main-thread:bindtouchend'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onTouchEndMT(toTouchEventMT(event, 'touchend'))
+    if (onTouchMoveMT) {
+      r['main-thread:bindtouchmove'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onTouchMoveMT(toTouchEventMT(event, 'touchmove'));
+      };
+      r['main-thread:bindmousemove'] = (event: MainThread.MouseEvent) => {
+        'main thread';
+        const buttons = (event as unknown as { buttons?: number }).buttons;
+        // Allow only left-button drags
+        if (!buttons || (buttons & 1) === 0) return;
+        onTouchMoveMT(toTouchEventMT(event, 'touchmove'));
+      };
     }
-    result['main-thread:bindmouseup'] = (event: MainThread.MouseEvent) => {
-      'main thread'
-      onTouchEndMT(toTouchEventMT(event, 'touchend'))
-    }
-  }
 
-  if (onTouchCancelMT) {
-    result['main-thread:bindtouchcancel'] = (event: MainThread.TouchEvent) => {
-      'main thread'
-      onTouchCancelMT(toTouchEventMT(event, 'touchend'))
+    if (onTouchEndMT) {
+      r['main-thread:bindtouchend'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onTouchEndMT(toTouchEventMT(event, 'touchend'));
+      };
+      r['main-thread:bindmouseup'] = (event: MainThread.MouseEvent) => {
+        'main thread';
+        onTouchEndMT(toTouchEventMT(event, 'touchend'));
+      };
     }
-  }
 
-  return result
+    if (onTouchCancelMT) {
+      r['main-thread:bindtouchcancel'] = (event: MainThread.TouchEvent) => {
+        'main thread';
+        onTouchCancelMT(toTouchEventMT(event, 'touchcancel'));
+      };
+    }
+
+    return r;
+  }, [
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    onTouchCancel,
+    onTouchStartMT,
+    onTouchMoveMT,
+    onTouchEndMT,
+    onTouchCancelMT,
+  ]);
+
+  return result;
 }
 
-export default useTouchEmulation
+export default useTouchEmulation;

--- a/tests/usePointerEvent.test.tsx
+++ b/tests/usePointerEvent.test.tsx
@@ -1,103 +1,275 @@
-import { type MainThreadRef, runOnMainThread, useMainThreadRef } from '@lynx-js/react'
-import { fireEvent, render } from '@lynx-js/react/testing-library'
-import { describe, expect, it, vi } from 'vitest'
-import usePointerEvent, { type CustomPointerEventMT } from '../src/usePointerEvent'
+import {
+  type MainThreadRef,
+  runOnMainThread,
+  useMainThreadRef,
+} from '@lynx-js/react';
+import { fireEvent, render } from '@lynx-js/react/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import usePointerEvent, {
+  type CustomPointerEventMT,
+} from '../src/usePointerEvent';
 
 describe('usePointerEvent (BT) integration', () => {
   it('binds mouse down and normalizes button/buttons', () => {
-    const onPointerDown = vi.fn()
+    const onPointerDown = vi.fn();
     const Comp = () => {
-      const props = usePointerEvent({ onPointerDown })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.mousedown(container.firstChild, { x: 10, y: 20, pageX: 110, pageY: 120, clientX: 210, clientY: 220, button: 1, buttons: 3 })
-    expect(onPointerDown).toHaveBeenCalledTimes(1)
-    const e = onPointerDown.mock.calls[0][0]
-    expect(e.pointerType).toBe('mouse')
-    expect(e.button).toBe(0)
-    expect(e.buttons).toBe(3)
-    expect(e.x).toBe(10)
-    expect(e.clientX).toBe(210)
-  })
+      const props = usePointerEvent({ onPointerDown });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousedown(container.firstChild, {
+      x: 10,
+      y: 20,
+      pageX: 110,
+      pageY: 120,
+      clientX: 210,
+      clientY: 220,
+      button: 1,
+      buttons: 3,
+    });
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    const e = onPointerDown.mock.calls[0][0];
+    expect(e.pointerType).toBe('mouse');
+    expect(e.button).toBe(0);
+    expect(e.buttons).toBe(3);
+    expect(e.x).toBe(10);
+    expect(e.clientX).toBe(210);
+  });
 
   it('binds touch start and normalizes detail/touch fields', () => {
-    const onPointerDown = vi.fn()
+    const onPointerDown = vi.fn();
     const Comp = () => {
-      const props = usePointerEvent({ onPointerDown })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.touchstart(container.firstChild, { detail: { x: 50, y: 60 }, touches: [{ identifier: 1, x: 51, y: 61, pageX: 151, pageY: 161, clientX: 251, clientY: 261 }] })
-    expect(onPointerDown).toHaveBeenCalledTimes(1)
-    const e = onPointerDown.mock.calls[0][0]
-    expect(e.pointerType).toBe('touch')
-    expect(e.x).toBe(151)
-    expect(e.y).toBe(161)
-    expect(e.pointerId).toBe(1)
-    expect(e.isPrimary).toBe(true)
-    expect(e.pageX).toBe(151)
-    expect(e.clientY).toBe(261)
-  })
-})
+      const props = usePointerEvent({ onPointerDown });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchstart(container.firstChild, {
+      detail: { x: 50, y: 60 },
+      touches: [{
+        identifier: 1,
+        x: 51,
+        y: 61,
+        pageX: 151,
+        pageY: 161,
+        clientX: 251,
+        clientY: 261,
+      }],
+    });
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    const e = onPointerDown.mock.calls[0][0];
+    expect(e.pointerType).toBe('touch');
+    expect(e.x).toBe(151);
+    expect(e.y).toBe(161);
+    expect(e.pointerId).toBe(1);
+    expect(e.isPrimary).toBe(true);
+    expect(e.pageX).toBe(151);
+    expect(e.clientY).toBe(261);
+  });
+});
 
 describe('usePointerEvent (MT) integration', () => {
   it('binds MT mouse down and normalizes button/buttons/targets', async () => {
-    let mtEventRef: MainThreadRef<CustomPointerEventMT | null>
+    let mtEventRef: MainThreadRef<CustomPointerEventMT | null>;
     const Comp = () => {
-      mtEventRef = useMainThreadRef<CustomPointerEventMT>(null)
+      mtEventRef = useMainThreadRef<CustomPointerEventMT>(null);
       const props = usePointerEvent({
         onPointerDownMT: (e) => {
-          'main thread'
-          mtEventRef.current = e
+          'main thread';
+          mtEventRef.current = e;
         },
-      })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.mousedown(container.firstChild, { x: 5, y: 6, pageX: 105, pageY: 106, clientX: 205, clientY: 206, button: 3, buttons: 1 })
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousedown(container.firstChild, {
+      x: 5,
+      y: 6,
+      pageX: 105,
+      pageY: 106,
+      clientX: 205,
+      clientY: 206,
+      button: 3,
+      buttons: 1,
+    });
     const read = runOnMainThread(() => {
-      'main thread'
-      return mtEventRef?.current
-    })
-    const e = await read() as CustomPointerEventMT
-    expect(e.pointerType).toBe('mouse')
-    expect(e.button).toBe(1)
-    expect(e.buttons).toBe(1)
+      'main thread';
+      return mtEventRef?.current;
+    });
+    const e = await read() as CustomPointerEventMT;
+    expect(e.pointerType).toBe('mouse');
+    expect(e.button).toBe(1);
+    expect(e.buttons).toBe(1);
     // target/currentTarget may be omitted in test env
-  })
+  });
 
   it('binds MT touch start and normalizes detail/touch fields', async () => {
-    let mtEventRef: MainThreadRef<CustomPointerEventMT | null>
+    let mtEventRef: MainThreadRef<CustomPointerEventMT | null>;
     const Comp = () => {
-      mtEventRef = useMainThreadRef<CustomPointerEventMT>(null)
+      mtEventRef = useMainThreadRef<CustomPointerEventMT>(null);
       const props = usePointerEvent({
         onPointerDownMT: (e) => {
-          'main thread'
-          mtEventRef.current = e
+          'main thread';
+          mtEventRef.current = e;
         },
-      })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.touchstart(container.firstChild, { detail: { x: 7, y: 8 }, touches: [{ identifier: 9, x: 0, y: 0, pageX: 100, pageY: 101, clientX: 200, clientY: 201 }] })
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchstart(container.firstChild, {
+      detail: { x: 7, y: 8 },
+      touches: [{
+        identifier: 9,
+        x: 0,
+        y: 0,
+        pageX: 100,
+        pageY: 101,
+        clientX: 200,
+        clientY: 201,
+      }],
+    });
     const read = runOnMainThread(() => {
-      'main thread'
-      return mtEventRef?.current
-    })
-    const e = await read() as CustomPointerEventMT
-    expect(e.pointerType).toBe('touch')
-    expect(e.x).toBe(100)
-    expect(e.y).toBe(101)
-    expect(e.pointerId).toBe(9)
+      'main thread';
+      return mtEventRef?.current;
+    });
+    const e = await read() as CustomPointerEventMT;
+    expect(e.pointerType).toBe('touch');
+    expect(e.x).toBe(100);
+    expect(e.y).toBe(101);
+    expect(e.pointerId).toBe(9);
     // target/currentTarget may be omitted in test env
-  })
-})
+  });
+});
+
+describe('usePointerEvent memoization', () => {
+  it('keeps props identity stable when handlers do not change', () => {
+    const onPointerMove = vi.fn();
+    let lastProps: ReturnType<typeof usePointerEvent> | undefined;
+
+    const Comp = ({ move }: { move: (e: unknown) => void }) => {
+      const props = usePointerEvent({ onPointerMove: move });
+      lastProps = props;
+      return <view {...props}></view>;
+    };
+
+    const { rerender } = render(<Comp move={onPointerMove} />);
+    const first = lastProps;
+    rerender(<Comp move={onPointerMove} />);
+    expect(lastProps).toBe(first);
+  });
+
+  it('recreates props identity when a handler changes', () => {
+    const onPointerMove1 = vi.fn();
+    const onPointerMove2 = vi.fn();
+    let lastProps: ReturnType<typeof usePointerEvent> | undefined;
+
+    const Comp = ({ move }: { move: (e: unknown) => void }) => {
+      const props = usePointerEvent({ onPointerMove: move });
+      lastProps = props;
+      return <view {...props}></view>;
+    };
+
+    const { rerender } = render(<Comp move={onPointerMove1} />);
+    const first = lastProps!;
+    rerender(<Comp move={onPointerMove2} />);
+    expect(lastProps).not.toBe(first);
+    expect(lastProps?.bindmousemove).not.toBe(first.bindmousemove);
+  });
+});
+
+describe('usePointerEvent move triggers', () => {
+  it('BT: onPointerMove triggers on mousemove without press', () => {
+    const onPointerMove = vi.fn();
+    const Comp = () => {
+      const props = usePointerEvent({ onPointerMove });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousemove(container.firstChild, {
+      x: 10,
+      y: 20,
+      pageX: 110,
+      pageY: 120,
+    });
+    expect(onPointerMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('BT: onPointerMove triggers on touchmove', () => {
+    const onPointerMove = vi.fn();
+    const Comp = () => {
+      const props = usePointerEvent({ onPointerMove });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchmove(container.firstChild, {
+      detail: { x: 50, y: 60 },
+      touches: [{
+        identifier: 1,
+        pageX: 151,
+        pageY: 161,
+        clientX: 251,
+        clientY: 261,
+      }],
+    });
+    expect(onPointerMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('MT: onPointerMoveMT triggers on mousemove without press', async () => {
+    let mtEventRef: MainThreadRef<CustomPointerEventMT | null>;
+    const Comp = () => {
+      mtEventRef = useMainThreadRef<CustomPointerEventMT>(null);
+      const props = usePointerEvent({
+        onPointerMoveMT: (e) => {
+          'main thread';
+          mtEventRef.current = e;
+        },
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousemove(container.firstChild, {
+      x: 10,
+      y: 20,
+      pageX: 110,
+      pageY: 120,
+    });
+    const read = runOnMainThread(() => {
+      'main thread';
+      return mtEventRef?.current;
+    });
+    const e = await read() as CustomPointerEventMT;
+    expect(e?.type).toBe('pointermove');
+    expect(e?.pointerType).toBe('mouse');
+  });
+
+  it('MT: onPointerMoveMT triggers on touchmove', async () => {
+    let mtEventRef: MainThreadRef<CustomPointerEventMT | null>;
+    const Comp = () => {
+      mtEventRef = useMainThreadRef<CustomPointerEventMT>(null);
+      const props = usePointerEvent({
+        onPointerMoveMT: (e) => {
+          'main thread';
+          mtEventRef.current = e;
+        },
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchmove(container.firstChild, {
+      detail: { x: 50, y: 60 },
+      touches: [{
+        identifier: 1,
+        pageX: 151,
+        pageY: 161,
+        clientX: 251,
+        clientY: 261,
+      }],
+    });
+    const read = runOnMainThread(() => {
+      'main thread';
+      return mtEventRef?.current;
+    });
+    const e = await read() as CustomPointerEventMT;
+    expect(e?.type).toBe('pointermove');
+    expect(e?.pointerType).toBe('touch');
+  });
+});

--- a/tests/useTouchEmulation.test.tsx
+++ b/tests/useTouchEmulation.test.tsx
@@ -1,138 +1,358 @@
-import { type MainThreadRef, runOnMainThread, useMainThreadRef } from '@lynx-js/react'
-import { fireEvent, render } from '@lynx-js/react/testing-library'
-import type { MainThread } from '@lynx-js/types'
-import { describe, expect, it, vi } from 'vitest'
-import useTouchEmulation from '../src/useTouchEmulation'
+import {
+  type MainThreadRef,
+  runOnMainThread,
+  useMainThreadRef,
+} from '@lynx-js/react';
+import { fireEvent, render } from '@lynx-js/react/testing-library';
+import type { MainThread } from '@lynx-js/types';
+import { describe, expect, it, vi } from 'vitest';
+import useTouchEmulation from '../src/useTouchEmulation';
 
 describe('useTouchEmulation (BT) integration', () => {
   it('synthesizes touch from mouse down', () => {
-    const onTouchStart = vi.fn()
+    const onTouchStart = vi.fn();
     const Comp = () => {
-      const props = useTouchEmulation({ onTouchStart })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.mousedown(container.firstChild, { x: 10, y: 20, pageX: 110, pageY: 120, clientX: 210, clientY: 220 })
-    expect(onTouchStart).toHaveBeenCalledTimes(1)
-    const e = onTouchStart.mock.calls[0][0] as unknown as TouchEvent
+      const props = useTouchEmulation({ onTouchStart });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousedown(container.firstChild, {
+      x: 10,
+      y: 20,
+      pageX: 110,
+      pageY: 120,
+      clientX: 210,
+      clientY: 220,
+    });
+    expect(onTouchStart).toHaveBeenCalledTimes(1);
+    const e = onTouchStart.mock.calls[0][0] as unknown as TouchEvent;
     // synthesized touch event fields
     // @ts-expect-error test environment type narrowing
-    expect(e.detail.x).toBe(110)
+    expect(e.detail.x).toBe(110);
     // @ts-expect-error test environment type narrowing
-    expect(e.detail.y).toBe(120)
-    expect(e.touches.length).toBe(1)
-    expect(e.changedTouches.length).toBe(1)
-    expect(e.touches[0].clientX).toBe(210)
-    expect(e.touches[0].pageY).toBe(120)
-  })
+    expect(e.detail.y).toBe(120);
+    expect(e.touches.length).toBe(1);
+    expect(e.changedTouches.length).toBe(1);
+    expect(e.touches[0].clientX).toBe(210);
+    expect(e.touches[0].pageY).toBe(120);
+  });
 
   it('passes through native touch start', () => {
-    const onTouchStart = vi.fn()
+    const onTouchStart = vi.fn();
     const Comp = () => {
-      const props = useTouchEmulation({ onTouchStart })
+      const props = useTouchEmulation({ onTouchStart });
 
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.touchstart(container.firstChild, { detail: { x: 50, y: 60 }, touches: [{ identifier: 2, x: 0, y: 0, pageX: 151, pageY: 161, clientX: 251, clientY: 261 }] })
-    expect(onTouchStart).toHaveBeenCalledTimes(1)
-    const e = onTouchStart.mock.calls[0][0] as unknown as TouchEvent
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchstart(container.firstChild, {
+      detail: { x: 50, y: 60 },
+      touches: [{
+        identifier: 2,
+        x: 0,
+        y: 0,
+        pageX: 151,
+        pageY: 161,
+        clientX: 251,
+        clientY: 261,
+      }],
+    });
+    expect(onTouchStart).toHaveBeenCalledTimes(1);
+    const e = onTouchStart.mock.calls[0][0] as unknown as TouchEvent;
     // @ts-expect-error test environment type narrowing
-    expect(e.detail.x).toBe(50)
-    expect(e.touches[0].identifier).toBe(2)
-    expect(e.touches[0].clientY).toBe(261)
-  })
+    expect(e.detail.x).toBe(50);
+    expect(e.touches[0].identifier).toBe(2);
+    expect(e.touches[0].clientY).toBe(261);
+  });
 
   it('synthesizes touchend from mouseup with empty touches', () => {
-    const onTouchEnd = vi.fn()
+    const onTouchEnd = vi.fn();
     const Comp = () => {
-      const props = useTouchEmulation({ onTouchEnd })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.mouseup(container.firstChild, { x: 1, y: 2, pageX: 101, pageY: 102, clientX: 201, clientY: 202 })
-    expect(onTouchEnd).toHaveBeenCalledTimes(1)
-    const e = onTouchEnd.mock.calls[0][0] as unknown as TouchEvent
+      const props = useTouchEmulation({ onTouchEnd });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mouseup(container.firstChild, {
+      x: 1,
+      y: 2,
+      pageX: 101,
+      pageY: 102,
+      clientX: 201,
+      clientY: 202,
+    });
+    expect(onTouchEnd).toHaveBeenCalledTimes(1);
+    const e = onTouchEnd.mock.calls[0][0] as unknown as TouchEvent;
     // @ts-expect-error test environment type narrowing
-    expect(e.detail.x).toBe(101)
-    expect(e.touches.length).toBe(0)
-    expect(e.changedTouches.length).toBe(1)
-  })
-})
+    expect(e.detail.x).toBe(101);
+    expect(e.touches.length).toBe(0);
+    expect(e.changedTouches.length).toBe(1);
+  });
+});
 
+describe('useTouchEmulation memoization', () => {
+  it('keeps props identity stable when handlers do not change', () => {
+    const onTouchStart = vi.fn();
+    const onTouchMove = vi.fn();
+    let lastProps: ReturnType<typeof useTouchEmulation> | undefined;
+
+    const Comp = ({ move }: { move: (e: unknown) => void }) => {
+      const props = useTouchEmulation({ onTouchStart, onTouchMove: move });
+      lastProps = props;
+      return <view {...props}></view>;
+    };
+
+    const { rerender } = render(<Comp move={onTouchMove} />);
+    const first = lastProps;
+    rerender(<Comp move={onTouchMove} />);
+    expect(lastProps).toBe(first);
+  });
+
+  it('recreates props identity when a handler changes', () => {
+    const onTouchStart = vi.fn();
+    const onTouchMove1 = vi.fn();
+    const onTouchMove2 = vi.fn();
+    let lastProps: ReturnType<typeof useTouchEmulation> | undefined;
+
+    const Comp = ({ move }: { move: (e: unknown) => void }) => {
+      const props = useTouchEmulation({ onTouchStart, onTouchMove: move });
+      lastProps = props;
+      return <view {...props}></view>;
+    };
+
+    const { rerender } = render(<Comp move={onTouchMove1} />);
+    const first = lastProps!;
+    rerender(<Comp move={onTouchMove2} />);
+    expect(lastProps).not.toBe(first);
+    expect(lastProps?.bindmousemove).not.toBe(first.bindmousemove);
+  });
+});
+
+describe('useTouchEmulation event semantics', () => {
+  it('BT: synthetic move from mousemove has correct coordinates', () => {
+    const onTouchMove = vi.fn();
+    const Comp = () => {
+      const props = useTouchEmulation({ onTouchMove });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    // Gate, then move
+    fireEvent.mousedown(container.firstChild, {
+      pageX: 10,
+      pageY: 20,
+      clientX: 30,
+      clientY: 40,
+    });
+    fireEvent.mousemove(container.firstChild, {
+      pageX: 15,
+      pageY: 25,
+      clientX: 35,
+      clientY: 45,
+      buttons: 1,
+    });
+    const e = onTouchMove.mock.calls[0][0] as unknown as TouchEvent;
+    // @ts-expect-error test environment type narrowing
+    expect(e.detail.x).toBe(15);
+    expect(e.touches.length).toBe(1);
+    expect(e.touches[0].pageY).toBe(25);
+    expect(e.touches[0].clientX).toBe(35);
+  });
+
+  it('BT: passes through native touchmove', () => {
+    const onTouchMove = vi.fn();
+    const Comp = () => {
+      const props = useTouchEmulation({ onTouchMove });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchmove(container.firstChild, {
+      detail: { x: 200, y: 100 },
+      touches: [{
+        identifier: 3,
+        pageX: 200,
+        pageY: 100,
+        clientX: 300,
+        clientY: 150,
+      }],
+    });
+    const e = onTouchMove.mock.calls[0][0] as unknown as TouchEvent;
+    // @ts-expect-error test environment type narrowing
+    expect(e.detail.x).toBe(200);
+    expect(e.touches[0].identifier).toBe(3);
+    expect(e.touches[0].clientY).toBe(150);
+  });
+
+  it('MT: synthetic move from mousemove has correct coordinates', async () => {
+    let mtEventRef: MainThreadRef<MainThread.TouchEvent | null>;
+    const Comp = () => {
+      mtEventRef = useMainThreadRef<MainThread.TouchEvent>(null);
+      const props = useTouchEmulation({
+        onTouchMoveMT: (e) => {
+          'main thread';
+          mtEventRef.current = e;
+        },
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousedown(container.firstChild, { pageX: 10, pageY: 20 });
+    fireEvent.mousemove(container.firstChild, {
+      pageX: 15,
+      pageY: 25,
+      buttons: 1,
+    });
+    const read = runOnMainThread(() => {
+      'main thread';
+      return mtEventRef?.current;
+    });
+    const e = await read();
+    // @ts-expect-error test environment type narrowing
+    expect(e?.detail.x).toBe(15);
+    // @ts-expect-error test environment type narrowing
+    expect(e?.touches.length).toBe(1);
+  });
+});
 describe('useTouchEmulation (MT) integration', () => {
   it('synthesizes MT touch from mouse down', async () => {
-    let mtEventRef: MainThreadRef<MainThread.TouchEvent | null>
+    let mtEventRef: MainThreadRef<MainThread.TouchEvent | null>;
     const Comp = () => {
-      mtEventRef = useMainThreadRef<MainThread.TouchEvent>(null)
+      mtEventRef = useMainThreadRef<MainThread.TouchEvent>(null);
       const props = useTouchEmulation({
         onTouchStartMT: (e) => {
-          'main thread'
-          mtEventRef.current = e
+          'main thread';
+          mtEventRef.current = e;
         },
-      })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.mousedown(container.firstChild, { x: 15, y: 25, pageX: 115, pageY: 125, clientX: 215, clientY: 225 })
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.mousedown(container.firstChild, {
+      x: 15,
+      y: 25,
+      pageX: 115,
+      pageY: 125,
+      clientX: 215,
+      clientY: 225,
+    });
     const read = runOnMainThread(() => {
-      'main thread'
-      return mtEventRef?.current
-    })
-    const e = await read()
+      'main thread';
+      return mtEventRef?.current;
+    });
+    const e = await read();
     // @ts-expect-error test environment type narrowing
-    expect(e?.detail.x).toBe(115)
+    expect(e?.detail.x).toBe(115);
     // @ts-expect-error test environment type narrowing
-    expect(e?.touches.length).toBe(1)
+    expect(e?.touches.length).toBe(1);
     // target/currentTarget may be omitted in test env
-  })
-})
+  });
+});
 
 describe('useTouchEmulation cancel behavior', () => {
-  it('BT: touchend triggers onTouchCancel and overrides onTouchEnd when both provided', () => {
-    const onTouchEnd = vi.fn()
-    const onTouchCancel = vi.fn()
+  it('BT: touchend triggers onTouchEnd only; touchcancel is separate', () => {
+    const onTouchEnd = vi.fn();
+    const onTouchCancel = vi.fn();
     const Comp = () => {
-      const props = useTouchEmulation({ onTouchEnd, onTouchCancel })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.touchend(container.firstChild, { detail: { x: 5, y: 6 }, touches: [] })
-    expect(onTouchCancel).toHaveBeenCalledTimes(1)
-    expect(onTouchEnd).toHaveBeenCalledTimes(0)
-  })
+      const props = useTouchEmulation({ onTouchEnd, onTouchCancel });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchend(container.firstChild, {
+      detail: { x: 5, y: 6 },
+      touches: [],
+    });
+    expect(onTouchEnd).toHaveBeenCalledTimes(1);
+    expect(onTouchCancel).toHaveBeenCalledTimes(0);
+  });
 
   it('MT: touchcancel triggers onTouchCancelMT when provided', async () => {
-    let mtCalledRef: MainThreadRef<boolean>
+    let mtCalledRef: MainThreadRef<boolean>;
     const Comp = () => {
-      mtCalledRef = useMainThreadRef<boolean>(false)
+      mtCalledRef = useMainThreadRef<boolean>(false);
       const props = useTouchEmulation({
         onTouchCancelMT: () => {
-          'main thread'
-          mtCalledRef.current = true
+          'main thread';
+          mtCalledRef.current = true;
         },
-      })
-      return (
-        <view {...props}></view>
-      )
-    }
-    const { container } = render(<Comp />)
-    fireEvent.touchcancel(container.firstChild, { detail: { x: 7, y: 8 }, touches: [] })
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    fireEvent.touchcancel(container.firstChild, {
+      detail: { x: 7, y: 8 },
+      touches: [],
+    });
     const read = runOnMainThread(() => {
-      'main thread'
-      return mtCalledRef?.current
-    })
-    const called = await read()
-    expect(called).toBe(true)
-  })
-})
+      'main thread';
+      return mtCalledRef?.current;
+    });
+    const called = await read();
+    expect(called).toBe(true);
+  });
+});
+
+describe('useTouchEmulation mouse gating behavior', () => {
+  it('BT: mousemove only triggers after mousedown and stops after mouseup', () => {
+    const onTouchMove = vi.fn();
+    const Comp = () => {
+      const props = useTouchEmulation({ onTouchMove });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    // Move without press should not trigger
+    fireEvent.mousemove(container.firstChild, { pageX: 10, pageY: 20 });
+    expect(onTouchMove).toHaveBeenCalledTimes(0);
+    // Press sets active and then move should trigger
+    fireEvent.mousedown(container.firstChild, { pageX: 10, pageY: 20 });
+    fireEvent.mousemove(container.firstChild, {
+      pageX: 15,
+      pageY: 25,
+      buttons: 1,
+    });
+    expect(onTouchMove).toHaveBeenCalledTimes(1);
+    // Release resets active and subsequent move should not trigger
+    fireEvent.mouseup(container.firstChild, { pageX: 15, pageY: 25 });
+    fireEvent.mousemove(container.firstChild, { pageX: 20, pageY: 30 });
+    expect(onTouchMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('MT: mousemove only triggers after mousedown and stops after mouseup', async () => {
+    let callCountRef: MainThreadRef<number>;
+    const Comp = () => {
+      callCountRef = useMainThreadRef<number>(0);
+      const props = useTouchEmulation({
+        onTouchMoveMT: () => {
+          'main thread';
+          callCountRef.current = (callCountRef.current ?? 0) + 1;
+        },
+      });
+      return <view {...props}></view>;
+    };
+    const { container } = render(<Comp />);
+    // Move without press should not trigger
+    fireEvent.mousemove(container.firstChild, { pageX: 10, pageY: 20 });
+    const read1 = runOnMainThread(() => {
+      'main thread';
+      return (callCountRef?.current ?? 0);
+    });
+    expect(await read1()).toBe(0);
+    // Press sets active and then move should trigger
+    fireEvent.mousedown(container.firstChild, { pageX: 10, pageY: 20 });
+    fireEvent.mousemove(container.firstChild, {
+      pageX: 15,
+      pageY: 25,
+      buttons: 1,
+    });
+    const read2 = runOnMainThread(() => {
+      'main thread';
+      return (callCountRef?.current ?? 0);
+    });
+    expect(await read2()).toBe(1);
+    // Release resets active and subsequent move should not trigger
+    fireEvent.mouseup(container.firstChild, { pageX: 15, pageY: 25 });
+    fireEvent.mousemove(container.firstChild, { pageX: 20, pageY: 30 });
+    const read3 = runOnMainThread(() => {
+      'main thread';
+      return (callCountRef?.current ?? 0);
+    });
+    expect(await read3()).toBe(1);
+  });
+});


### PR DESCRIPTION
For mouseMove event, it will be called whenever mouse moves, which is different from touchMove event, who will only be called after touchStart.

This change unifies the differences.

And also, add some optimization for memoization and bundle size by using `'background only'`