### PR TITLE
feat: support event binding modes

### DIFF
--- a/.changeset/beige-pans-enter.md
+++ b/.changeset/beige-pans-enter.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/react-use': patch
+---
+
+Update `useTouchEmulation` and `usePointerEvent` to support catch, capture-bind, and capture-catch event modes.

--- a/docs/en/mts/usePointerEvent.md
+++ b/docs/en/mts/usePointerEvent.md
@@ -26,7 +26,10 @@ function App() {
 ## Type Declarations
 
 ```tsx
-type PointerAction = 'pointerdown' | 'pointermove' | 'pointerup';
+type PointerAction = 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel';
+type BindingMode = 'bind' | 'catch' | 'capture-bind' | 'capture-catch';
+type PointerCallbackPrefix = 'on' | 'catch' | 'captureBind' | 'captureCatch';
+type PointerActionName = 'Down' | 'Move' | 'Up' | 'Cancel';
 
 interface CustomPointerEvent {
     type: PointerAction;
@@ -51,26 +54,37 @@ interface CustomPointerEventMT extends CustomPointerEvent {
     originalEvent: MainThread.MouseEvent | MainThread.TouchEvent;
 }
 
-function usePointerEvent({ onPointerDown, onPointerUp, onPointerMove, onPointerUpMT, onPointerMoveMT, onPointerDownMT, }: {
-    onPointerDown?: (event: CustomPointerEvent) => void;
-    onPointerUp?: (event: CustomPointerEvent) => void;
-    onPointerMove?: (event: CustomPointerEvent) => void;
-    onPointerUpMT?: (event: CustomPointerEventMT) => void;
-    onPointerMoveMT?: (event: CustomPointerEventMT) => void;
-    onPointerDownMT?: (event: CustomPointerEventMT) => void;
+type PointerCallbackName =
+  `${PointerCallbackPrefix}Pointer${PointerActionName}${'' | 'MT'}`;
+
+type TouchEventProp =
+  `${BindingMode}${'touchstart' | 'touchmove' | 'touchend' | 'touchcancel'}`;
+type MouseEventProp =
+  `${BindingMode}${'mousedown' | 'mousemove' | 'mouseup'}`;
+type MainThreadEventProp<EventName extends string> =
+  `main-thread:${BindingMode}${EventName}`;
+
+function usePointerEvent(options: {
+  [K in PointerCallbackName]?: K extends `${string}MT`
+    ? (event: CustomPointerEventMT) => void
+    : (event: CustomPointerEvent) => void;
 }): {
-    'bindmousedown'?: (e: MouseEvent) => void;
-    'bindtouchstart'?: (e: TouchEvent) => void;
-    'bindmousemove'?: (e: MouseEvent) => void;
-    'bindtouchmove'?: (e: TouchEvent) => void;
-    'bindmouseup'?: (e: MouseEvent) => void;
-    'bindtouchend'?: (e: TouchEvent) => void;
-    'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
-    'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
-    'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
-    'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
-    'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
-    'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
+  [K in TouchEventProp]?: (event: TouchEvent) => void;
+} & {
+  [K in MouseEventProp]?: (event: MouseEvent) => void;
+} & {
+  [K in MainThreadEventProp<'touchstart' | 'touchmove' | 'touchend' | 'touchcancel'>]?: (event: MainThread.TouchEvent) => void;
+} & {
+  [K in MainThreadEventProp<'mousedown' | 'mousemove' | 'mouseup'>]?: (event: MainThread.MouseEvent) => void;
 };
 
 ```
+
+Callback prefixes map to event binding modes:
+
+- `onPointerDown` -> `bindmousedown` and `bindtouchstart`
+- `catchPointerDown` -> `catchmousedown` and `catchtouchstart`
+- `captureBindPointerDown` -> `capture-bindmousedown` and `capture-bindtouchstart`
+- `captureCatchPointerDown` -> `capture-catchmousedown` and `capture-catchtouchstart`
+
+Append `MT` to use the main-thread variants, for example `captureCatchPointerDownMT` maps to `main-thread:capture-catchmousedown` and `main-thread:capture-catchtouchstart`.

--- a/docs/en/mts/useTouchEmulation.md
+++ b/docs/en/mts/useTouchEmulation.md
@@ -25,36 +25,42 @@ function App() {
 ## Type Declarations
 
 ```tsx
-type TouchAction = 'touchstart' | 'touchmove' | 'touchend';
+type TouchAction = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
+type BindingMode = 'bind' | 'catch' | 'capture-bind' | 'capture-catch';
+type TouchCallbackPrefix = 'on' | 'catch' | 'captureBind' | 'captureCatch';
+type TouchActionName = 'Start' | 'Move' | 'End' | 'Cancel';
 
-function useTouchEmulation({
-  onTouchStart,
-  onTouchMove,
-  onTouchEnd,
-  onTouchStartMT,
-  onTouchMoveMT,
-  onTouchEndMT,
-}: {
-  onTouchStart?: (event: TouchEvent) => void;
-  onTouchMove?: (event: TouchEvent) => void;
-  onTouchEnd?: (event: TouchEvent) => void;
-  onTouchStartMT?: (event: MainThread.TouchEvent) => void;
-  onTouchMoveMT?: (event: MainThread.TouchEvent) => void;
-  onTouchEndMT?: (event: MainThread.TouchEvent) => void;
+type TouchCallbackName =
+  `${TouchCallbackPrefix}Touch${TouchActionName}${'' | 'MT'}`;
+
+type TouchEventProp = `${BindingMode}${TouchAction}`;
+type MouseEventProp =
+  `${BindingMode}${'mousedown' | 'mousemove' | 'mouseup'}`;
+type MainThreadEventProp<EventName extends string> =
+  `main-thread:${BindingMode}${EventName}`;
+
+function useTouchEmulation(options: {
+  [K in TouchCallbackName]?: K extends `${string}MT`
+    ? (event: MainThread.TouchEvent) => void
+    : (event: TouchEvent) => void;
 }): {
-  'bindtouchstart'?: (e: TouchEvent) => void;
-  'bindmousedown'?: (e: MouseEvent) => void;
-  'bindtouchmove'?: (e: TouchEvent) => void;
-  'bindmousemove'?: (e: MouseEvent) => void;
-  'bindtouchend'?: (e: TouchEvent) => void;
-  'bindmouseup'?: (e: MouseEvent) => void;
-  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
+  [K in TouchEventProp]?: (event: TouchEvent) => void;
+} & {
+  [K in MouseEventProp]?: (event: MouseEvent) => void;
+} & {
+  [K in MainThreadEventProp<TouchAction>]?: (event: MainThread.TouchEvent) => void;
+} & {
+  [K in MainThreadEventProp<'mousedown' | 'mousemove' | 'mouseup'>]?: (event: MainThread.MouseEvent) => void;
 };
 
 // Alias: useTouchEvent provides the same API
 ```
+
+Callback prefixes map to event binding modes:
+
+- `onTouchStart` -> `bindtouchstart` and `bindmousedown`
+- `catchTouchStart` -> `catchtouchstart` and `catchmousedown`
+- `captureBindTouchStart` -> `capture-bindtouchstart` and `capture-bindmousedown`
+- `captureCatchTouchStart` -> `capture-catchtouchstart` and `capture-catchmousedown`
+
+Append `MT` to use the main-thread variants, for example `captureCatchTouchStartMT` maps to `main-thread:capture-catchtouchstart` and `main-thread:capture-catchmousedown`.

--- a/docs/zh/mts/usePointerEvent.md
+++ b/docs/zh/mts/usePointerEvent.md
@@ -26,7 +26,10 @@ function App() {
 ## 类型定义
 
 ```tsx
-type PointerAction = 'pointerdown' | 'pointermove' | 'pointerup';
+type PointerAction = 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel';
+type BindingMode = 'bind' | 'catch' | 'capture-bind' | 'capture-catch';
+type PointerCallbackPrefix = 'on' | 'catch' | 'captureBind' | 'captureCatch';
+type PointerActionName = 'Down' | 'Move' | 'Up' | 'Cancel';
 
 interface CustomPointerEvent {
     type: PointerAction;
@@ -51,26 +54,37 @@ interface CustomPointerEventMT extends CustomPointerEvent {
     originalEvent: MainThread.MouseEvent | MainThread.TouchEvent;
 }
 
-function usePointerEvent({ onPointerDown, onPointerUp, onPointerMove, onPointerUpMT, onPointerMoveMT, onPointerDownMT, }: {
-    onPointerDown?: (event: CustomPointerEvent) => void;
-    onPointerUp?: (event: CustomPointerEvent) => void;
-    onPointerMove?: (event: CustomPointerEvent) => void;
-    onPointerUpMT?: (event: CustomPointerEventMT) => void;
-    onPointerMoveMT?: (event: CustomPointerEventMT) => void;
-    onPointerDownMT?: (event: CustomPointerEventMT) => void;
+type PointerCallbackName =
+  `${PointerCallbackPrefix}Pointer${PointerActionName}${'' | 'MT'}`;
+
+type TouchEventProp =
+  `${BindingMode}${'touchstart' | 'touchmove' | 'touchend' | 'touchcancel'}`;
+type MouseEventProp =
+  `${BindingMode}${'mousedown' | 'mousemove' | 'mouseup'}`;
+type MainThreadEventProp<EventName extends string> =
+  `main-thread:${BindingMode}${EventName}`;
+
+function usePointerEvent(options: {
+  [K in PointerCallbackName]?: K extends `${string}MT`
+    ? (event: CustomPointerEventMT) => void
+    : (event: CustomPointerEvent) => void;
 }): {
-    'bindmousedown'?: (e: MouseEvent) => void;
-    'bindtouchstart'?: (e: TouchEvent) => void;
-    'bindmousemove'?: (e: MouseEvent) => void;
-    'bindtouchmove'?: (e: TouchEvent) => void;
-    'bindmouseup'?: (e: MouseEvent) => void;
-    'bindtouchend'?: (e: TouchEvent) => void;
-    'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
-    'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
-    'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
-    'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
-    'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
-    'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
+  [K in TouchEventProp]?: (event: TouchEvent) => void;
+} & {
+  [K in MouseEventProp]?: (event: MouseEvent) => void;
+} & {
+  [K in MainThreadEventProp<'touchstart' | 'touchmove' | 'touchend' | 'touchcancel'>]?: (event: MainThread.TouchEvent) => void;
+} & {
+  [K in MainThreadEventProp<'mousedown' | 'mousemove' | 'mouseup'>]?: (event: MainThread.MouseEvent) => void;
 };
 
 ```
+
+回调前缀会映射到对应的事件绑定模式：
+
+- `onPointerDown` -> `bindmousedown` 和 `bindtouchstart`
+- `catchPointerDown` -> `catchmousedown` 和 `catchtouchstart`
+- `captureBindPointerDown` -> `capture-bindmousedown` 和 `capture-bindtouchstart`
+- `captureCatchPointerDown` -> `capture-catchmousedown` 和 `capture-catchtouchstart`
+
+追加 `MT` 可以使用主线程版本，例如 `captureCatchPointerDownMT` 会映射到 `main-thread:capture-catchmousedown` 和 `main-thread:capture-catchtouchstart`。

--- a/docs/zh/mts/useTouchEmulation.md
+++ b/docs/zh/mts/useTouchEmulation.md
@@ -25,36 +25,42 @@ function App() {
 ## 类型定义
 
 ```tsx
-type TouchAction = 'touchstart' | 'touchmove' | 'touchend';
+type TouchAction = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
+type BindingMode = 'bind' | 'catch' | 'capture-bind' | 'capture-catch';
+type TouchCallbackPrefix = 'on' | 'catch' | 'captureBind' | 'captureCatch';
+type TouchActionName = 'Start' | 'Move' | 'End' | 'Cancel';
 
-function useTouchEmulation({
-  onTouchStart,
-  onTouchMove,
-  onTouchEnd,
-  onTouchStartMT,
-  onTouchMoveMT,
-  onTouchEndMT,
-}: {
-  onTouchStart?: (event: TouchEvent) => void;
-  onTouchMove?: (event: TouchEvent) => void;
-  onTouchEnd?: (event: TouchEvent) => void;
-  onTouchStartMT?: (event: MainThread.TouchEvent) => void;
-  onTouchMoveMT?: (event: MainThread.TouchEvent) => void;
-  onTouchEndMT?: (event: MainThread.TouchEvent) => void;
+type TouchCallbackName =
+  `${TouchCallbackPrefix}Touch${TouchActionName}${'' | 'MT'}`;
+
+type TouchEventProp = `${BindingMode}${TouchAction}`;
+type MouseEventProp =
+  `${BindingMode}${'mousedown' | 'mousemove' | 'mouseup'}`;
+type MainThreadEventProp<EventName extends string> =
+  `main-thread:${BindingMode}${EventName}`;
+
+function useTouchEmulation(options: {
+  [K in TouchCallbackName]?: K extends `${string}MT`
+    ? (event: MainThread.TouchEvent) => void
+    : (event: TouchEvent) => void;
 }): {
-  'bindtouchstart'?: (e: TouchEvent) => void;
-  'bindmousedown'?: (e: MouseEvent) => void;
-  'bindtouchmove'?: (e: TouchEvent) => void;
-  'bindmousemove'?: (e: MouseEvent) => void;
-  'bindtouchend'?: (e: TouchEvent) => void;
-  'bindmouseup'?: (e: MouseEvent) => void;
-  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
+  [K in TouchEventProp]?: (event: TouchEvent) => void;
+} & {
+  [K in MouseEventProp]?: (event: MouseEvent) => void;
+} & {
+  [K in MainThreadEventProp<TouchAction>]?: (event: MainThread.TouchEvent) => void;
+} & {
+  [K in MainThreadEventProp<'mousedown' | 'mousemove' | 'mouseup'>]?: (event: MainThread.MouseEvent) => void;
 };
 
 // 别名：useTouchEvent 提供相同的 API
 ```
+
+回调前缀会映射到对应的事件绑定模式：
+
+- `onTouchStart` -> `bindtouchstart` 和 `bindmousedown`
+- `catchTouchStart` -> `catchtouchstart` 和 `catchmousedown`
+- `captureBindTouchStart` -> `capture-bindtouchstart` 和 `capture-bindmousedown`
+- `captureCatchTouchStart` -> `capture-catchtouchstart` 和 `capture-catchmousedown`
+
+追加 `MT` 可以使用主线程版本，例如 `captureCatchTouchStartMT` 会映射到 `main-thread:capture-catchtouchstart` 和 `main-thread:capture-catchmousedown`。

--- a/src/usePointerEvent.ts
+++ b/src/usePointerEvent.ts
@@ -6,6 +6,24 @@ type PointerAction =
   | 'pointermove'
   | 'pointerup'
   | 'pointercancel';
+type BindingMode = 'bind' | 'catch' | 'capture-bind' | 'capture-catch';
+type PointerTouchEventName =
+  | 'touchstart'
+  | 'touchmove'
+  | 'touchend'
+  | 'touchcancel';
+type PointerMouseEventName = 'mousedown' | 'mousemove' | 'mouseup';
+type PointerActionName = 'Down' | 'Move' | 'Up' | 'Cancel';
+type CallbackPrefix = 'on' | 'catch' | 'captureBind' | 'captureCatch';
+type PointerCallbackName =
+  `${CallbackPrefix}Pointer${PointerActionName}${'' | 'MT'}`;
+type EventProp<EventName extends string> = `${BindingMode}${EventName}`;
+type MainThreadEventProp<EventName extends string> =
+  `main-thread:${EventProp<EventName>}`;
+
+type OptionalHandlers<Key extends string, Event> = {
+  [K in Key]?: (event: Event) => void;
+};
 
 interface CustomPointerEvent {
   type: PointerAction;
@@ -24,28 +42,76 @@ interface CustomPointerEvent {
   originalEvent: unknown;
 }
 
-interface UsePointerEventReturn {
-  bindmousedown?: (e: MouseEvent) => void;
-  bindtouchstart?: (e: TouchEvent) => void;
-  bindmousemove?: (e: MouseEvent) => void;
-  bindtouchmove?: (e: TouchEvent) => void;
-  bindmouseup?: (e: MouseEvent) => void;
-  bindtouchend?: (e: TouchEvent) => void;
-  bindtouchcancel?: (e: TouchEvent) => void;
-  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindtouchcancel'?: (e: MainThread.TouchEvent) => void;
-}
+type UsePointerEventReturn =
+  & OptionalHandlers<EventProp<PointerMouseEventName>, MouseEvent>
+  & OptionalHandlers<EventProp<PointerTouchEventName>, TouchEvent>
+  & OptionalHandlers<MainThreadEventProp<PointerMouseEventName>, MainThread.MouseEvent>
+  & OptionalHandlers<MainThreadEventProp<PointerTouchEventName>, MainThread.TouchEvent>;
+
+type UsePointerEventOptions =
+  & OptionalHandlers<
+    Exclude<PointerCallbackName, `${string}MT`>,
+    CustomPointerEvent
+  >
+  & OptionalHandlers<
+    Extract<PointerCallbackName, `${string}MT`>,
+    CustomPointerEventMT
+  >;
 
 interface CustomPointerEventMT extends CustomPointerEvent {
   target: MainThread.Element;
   currentTarget: MainThread.Element;
   originalEvent: MainThread.MouseEvent | MainThread.TouchEvent;
 }
+
+const bindingModes = [
+  { eventPrefix: 'bind', callbackPrefix: 'on' },
+  { eventPrefix: 'catch', callbackPrefix: 'catch' },
+  { eventPrefix: 'capture-bind', callbackPrefix: 'captureBind' },
+  { eventPrefix: 'capture-catch', callbackPrefix: 'captureCatch' },
+] as const satisfies ReadonlyArray<{
+  eventPrefix: BindingMode;
+  callbackPrefix: CallbackPrefix;
+}>;
+
+const pointerActions = [
+  {
+    name: 'Down',
+    mouseEvent: 'mousedown',
+    touchEvent: 'touchstart',
+    action: 'pointerdown',
+  },
+  {
+    name: 'Move',
+    mouseEvent: 'mousemove',
+    touchEvent: 'touchmove',
+    action: 'pointermove',
+  },
+  {
+    name: 'Up',
+    mouseEvent: 'mouseup',
+    touchEvent: 'touchend',
+    action: 'pointerup',
+  },
+  {
+    name: 'Cancel',
+    mouseEvent: undefined,
+    touchEvent: 'touchcancel',
+    action: 'pointercancel',
+  },
+] as const satisfies ReadonlyArray<{
+  name: PointerActionName;
+  mouseEvent?: PointerMouseEventName;
+  touchEvent: PointerTouchEventName;
+  action: PointerAction;
+}>;
+
+const pointerCallbackKeys = pointerActions.flatMap(({ name }) =>
+  bindingModes.flatMap(({ callbackPrefix }) => [
+    `${callbackPrefix}Pointer${name}`,
+    `${callbackPrefix}Pointer${name}MT`,
+  ])
+) as PointerCallbackName[];
 
 function unifyPointerEvent(
   event: MouseEvent | TouchEvent,
@@ -163,119 +229,89 @@ function unifyPointerEventMT(
 
 // Button mapping is inlined in both BG and MT normalizers
 
-function usePointerEvent({
-  onPointerDown,
-  onPointerUp,
-  onPointerMove,
-  onPointerCancel,
-  onPointerUpMT,
-  onPointerMoveMT,
-  onPointerDownMT,
-  onPointerCancelMT,
-}: {
-  onPointerDown?: (event: CustomPointerEvent) => void;
-  onPointerUp?: (event: CustomPointerEvent) => void;
-  onPointerMove?: (event: CustomPointerEvent) => void;
-  onPointerCancel?: (event: CustomPointerEvent) => void;
-  onPointerUpMT?: (event: CustomPointerEventMT) => void;
-  onPointerMoveMT?: (event: CustomPointerEventMT) => void;
-  onPointerDownMT?: (event: CustomPointerEventMT) => void;
-  onPointerCancelMT?: (event: CustomPointerEventMT) => void;
-}): UsePointerEventReturn {
+function addPointerHandler(
+  result: UsePointerEventReturn,
+  mode: BindingMode,
+  mouseEvent: PointerMouseEventName | undefined,
+  touchEvent: PointerTouchEventName,
+  action: PointerAction,
+  handler: ((event: CustomPointerEvent) => void) | undefined,
+) {
+  if (!handler) return;
+
+  const target = result as Record<string, unknown>;
+  if (mouseEvent) {
+    target[`${mode}${mouseEvent}`] = (event: MouseEvent) => {
+      'background only';
+      handler(unifyPointerEvent(event, action));
+    };
+  }
+  target[`${mode}${touchEvent}`] = (event: TouchEvent) => {
+    'background only';
+    handler(unifyPointerEvent(event, action));
+  };
+}
+
+function addPointerHandlerMT(
+  result: UsePointerEventReturn,
+  mode: BindingMode,
+  mouseEvent: PointerMouseEventName | undefined,
+  touchEvent: PointerTouchEventName,
+  action: PointerAction,
+  handler: ((event: CustomPointerEventMT) => void) | undefined,
+) {
+  if (!handler) return;
+
+  const target = result as Record<string, unknown>;
+  if (mouseEvent) {
+    target[`main-thread:${mode}${mouseEvent}`] = (event: MainThread.MouseEvent) => {
+      'main thread';
+      handler(unifyPointerEventMT(event, action));
+    };
+  }
+  target[`main-thread:${mode}${touchEvent}`] = (event: MainThread.TouchEvent) => {
+    'main thread';
+    handler(unifyPointerEventMT(event, action));
+  };
+}
+
+function usePointerEvent(options: UsePointerEventOptions): UsePointerEventReturn {
+  const dependencies = pointerCallbackKeys.map((key) => options[key]);
   const result = useMemo<UsePointerEventReturn>(() => {
     const r: UsePointerEventReturn = {};
 
-    if (onPointerDown) {
-      r.bindmousedown = (event: MouseEvent) => {
-        'background only';
-        onPointerDown(unifyPointerEvent(event, 'pointerdown'));
-      };
-      r.bindtouchstart = (event: TouchEvent) => {
-        'background only';
-        onPointerDown(unifyPointerEvent(event, 'pointerdown'));
-      };
-    }
+    for (const mode of bindingModes) {
+      for (const action of pointerActions) {
+        const callbackKey =
+          `${mode.callbackPrefix}Pointer${action.name}` as PointerCallbackName;
+        const callbackMTKey =
+          `${mode.callbackPrefix}Pointer${action.name}MT` as PointerCallbackName;
 
-    if (onPointerMove) {
-      r.bindmousemove = (event: MouseEvent) => {
-        'background only';
-        onPointerMove(unifyPointerEvent(event, 'pointermove'));
-      };
-      r.bindtouchmove = (event: TouchEvent) => {
-        'background only';
-        onPointerMove(unifyPointerEvent(event, 'pointermove'));
-      };
-    }
-
-    if (onPointerUp) {
-      r.bindmouseup = (event: MouseEvent) => {
-        'background only';
-        onPointerUp(unifyPointerEvent(event, 'pointerup'));
-      };
-      r.bindtouchend = (event: TouchEvent) => {
-        'background only';
-        onPointerUp(unifyPointerEvent(event, 'pointerup'));
-      };
-    }
-
-    if (onPointerCancel) {
-      r.bindtouchcancel = (event: TouchEvent) => {
-        'background only';
-        onPointerCancel(unifyPointerEvent(event, 'pointercancel'));
-      };
-    }
-
-    if (onPointerDownMT) {
-      r['main-thread:bindmousedown'] = (event: MainThread.MouseEvent) => {
-        'main thread';
-        onPointerDownMT(unifyPointerEventMT(event, 'pointerdown'));
-      };
-      r['main-thread:bindtouchstart'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onPointerDownMT(unifyPointerEventMT(event, 'pointerdown'));
-      };
-    }
-
-    if (onPointerMoveMT) {
-      r['main-thread:bindmousemove'] = (event: MainThread.MouseEvent) => {
-        'main thread';
-        onPointerMoveMT(unifyPointerEventMT(event, 'pointermove'));
-      };
-      r['main-thread:bindtouchmove'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onPointerMoveMT(unifyPointerEventMT(event, 'pointermove'));
-      };
-    }
-
-    if (onPointerUpMT) {
-      r['main-thread:bindmouseup'] = (event: MainThread.MouseEvent) => {
-        'main thread';
-        onPointerUpMT(unifyPointerEventMT(event, 'pointerup'));
-      };
-      r['main-thread:bindtouchend'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onPointerUpMT(unifyPointerEventMT(event, 'pointerup'));
-      };
-    }
-
-    if (onPointerCancelMT) {
-      r['main-thread:bindtouchcancel'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onPointerCancelMT(unifyPointerEventMT(event, 'pointercancel'));
-      };
+        addPointerHandler(
+          r,
+          mode.eventPrefix,
+          action.mouseEvent,
+          action.touchEvent,
+          action.action,
+          options[callbackKey] as
+            | ((event: CustomPointerEvent) => void)
+            | undefined,
+        );
+        addPointerHandlerMT(
+          r,
+          mode.eventPrefix,
+          action.mouseEvent,
+          action.touchEvent,
+          action.action,
+          options[callbackMTKey] as
+            | ((event: CustomPointerEventMT) => void)
+            | undefined,
+        );
+      }
     }
 
     return r;
-  }, [
-    onPointerDown,
-    onPointerUp,
-    onPointerMove,
-    onPointerCancel,
-    onPointerUpMT,
-    onPointerMoveMT,
-    onPointerDownMT,
-    onPointerCancelMT,
-  ]);
+  }, dependencies);
 
   return result;
 }

--- a/src/useTouchEmulation.ts
+++ b/src/useTouchEmulation.ts
@@ -2,23 +2,79 @@ import { useMemo } from '@lynx-js/react';
 import type { MainThread, MouseEvent, Touch, TouchEvent } from '@lynx-js/types';
 
 type TouchAction = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
+type BindingMode = 'bind' | 'catch' | 'capture-bind' | 'capture-catch';
+type TouchEventName = TouchAction;
+type MouseEventName = 'mousedown' | 'mousemove' | 'mouseup';
+type TouchActionName = 'Start' | 'Move' | 'End' | 'Cancel';
+type CallbackPrefix = 'on' | 'catch' | 'captureBind' | 'captureCatch';
+type TouchCallbackName =
+  `${CallbackPrefix}Touch${TouchActionName}${'' | 'MT'}`;
+type EventProp<EventName extends string> = `${BindingMode}${EventName}`;
+type MainThreadEventProp<EventName extends string> =
+  `main-thread:${EventProp<EventName>}`;
 
-interface UseTouchEmulationReturn {
-  bindtouchstart?: (e: TouchEvent) => void;
-  bindmousedown?: (e: MouseEvent) => void;
-  bindtouchmove?: (e: TouchEvent) => void;
-  bindmousemove?: (e: MouseEvent) => void;
-  bindtouchend?: (e: TouchEvent) => void;
-  bindtouchcancel?: (e: TouchEvent) => void;
-  bindmouseup?: (e: MouseEvent) => void;
-  'main-thread:bindtouchstart'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousedown'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchmove'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmousemove'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchend'?: (e: MainThread.TouchEvent) => void;
-  'main-thread:bindmouseup'?: (e: MainThread.MouseEvent) => void;
-  'main-thread:bindtouchcancel'?: (e: MainThread.TouchEvent) => void;
-}
+type OptionalHandlers<Key extends string, Event> = {
+  [K in Key]?: (event: Event) => void;
+};
+
+type UseTouchEmulationReturn =
+  & OptionalHandlers<EventProp<TouchEventName>, TouchEvent>
+  & OptionalHandlers<EventProp<MouseEventName>, MouseEvent>
+  & OptionalHandlers<MainThreadEventProp<TouchEventName>, MainThread.TouchEvent>
+  & OptionalHandlers<MainThreadEventProp<MouseEventName>, MainThread.MouseEvent>;
+
+type UseTouchEmulationOptions =
+  & OptionalHandlers<Exclude<TouchCallbackName, `${string}MT`>, TouchEvent>
+  & OptionalHandlers<Extract<TouchCallbackName, `${string}MT`>, MainThread.TouchEvent>;
+
+const bindingModes = [
+  { eventPrefix: 'bind', callbackPrefix: 'on' },
+  { eventPrefix: 'catch', callbackPrefix: 'catch' },
+  { eventPrefix: 'capture-bind', callbackPrefix: 'captureBind' },
+  { eventPrefix: 'capture-catch', callbackPrefix: 'captureCatch' },
+] as const satisfies ReadonlyArray<{
+  eventPrefix: BindingMode;
+  callbackPrefix: CallbackPrefix;
+}>;
+
+const touchActions = [
+  {
+    name: 'Start',
+    touchEvent: 'touchstart',
+    mouseEvent: 'mousedown',
+    action: 'touchstart',
+  },
+  {
+    name: 'Move',
+    touchEvent: 'touchmove',
+    mouseEvent: 'mousemove',
+    action: 'touchmove',
+  },
+  {
+    name: 'End',
+    touchEvent: 'touchend',
+    mouseEvent: 'mouseup',
+    action: 'touchend',
+  },
+  {
+    name: 'Cancel',
+    touchEvent: 'touchcancel',
+    mouseEvent: undefined,
+    action: 'touchcancel',
+  },
+] as const satisfies ReadonlyArray<{
+  name: TouchActionName;
+  touchEvent: TouchEventName;
+  mouseEvent?: MouseEventName;
+  action: TouchAction;
+}>;
+
+const touchCallbackKeys = touchActions.flatMap(({ name }) =>
+  bindingModes.flatMap(({ callbackPrefix }) => [
+    `${callbackPrefix}Touch${name}`,
+    `${callbackPrefix}Touch${name}MT`,
+  ])
+) as TouchCallbackName[];
 
 function toTouchEvent(
   event: MouseEvent | TouchEvent,
@@ -72,126 +128,99 @@ function toTouchEventMT(
   } as unknown as MainThread.TouchEvent;
 }
 
-function useTouchEmulation({
-  onTouchStart,
-  onTouchMove,
-  onTouchEnd,
-  onTouchCancel,
-  onTouchStartMT,
-  onTouchMoveMT,
-  onTouchEndMT,
-  onTouchCancelMT,
-}: {
-  onTouchStart?: (event: TouchEvent) => void;
-  onTouchMove?: (event: TouchEvent) => void;
-  onTouchEnd?: (event: TouchEvent) => void;
-  onTouchCancel?: (event: TouchEvent) => void;
-  onTouchStartMT?: (event: MainThread.TouchEvent) => void;
-  onTouchMoveMT?: (event: MainThread.TouchEvent) => void;
-  onTouchEndMT?: (event: MainThread.TouchEvent) => void;
-  onTouchCancelMT?: (event: MainThread.TouchEvent) => void;
-}): UseTouchEmulationReturn {
+function addTouchHandler(
+  result: UseTouchEmulationReturn,
+  mode: BindingMode,
+  touchEvent: TouchEventName,
+  mouseEvent: MouseEventName | undefined,
+  action: TouchAction,
+  handler: ((event: TouchEvent) => void) | undefined,
+) {
+  if (!handler) return;
+
+  const target = result as Record<string, unknown>;
+  target[`${mode}${touchEvent}`] = (event: TouchEvent) => {
+    'background only';
+    handler(toTouchEvent(event, action));
+  };
+
+  if (!mouseEvent) return;
+  target[`${mode}${mouseEvent}`] = (event: MouseEvent) => {
+    'background only';
+    if (action === 'touchmove') {
+      const buttons = (event as unknown as { buttons?: number }).buttons;
+      // Allow only left-button drags
+      if (!buttons || (buttons & 1) === 0) return;
+    }
+    handler(toTouchEvent(event, action));
+  };
+}
+
+function addTouchHandlerMT(
+  result: UseTouchEmulationReturn,
+  mode: BindingMode,
+  touchEvent: TouchEventName,
+  mouseEvent: MouseEventName | undefined,
+  action: TouchAction,
+  handler: ((event: MainThread.TouchEvent) => void) | undefined,
+) {
+  if (!handler) return;
+
+  const target = result as Record<string, unknown>;
+  target[`main-thread:${mode}${touchEvent}`] = (event: MainThread.TouchEvent) => {
+    'main thread';
+    handler(toTouchEventMT(event, action));
+  };
+
+  if (!mouseEvent) return;
+  target[`main-thread:${mode}${mouseEvent}`] = (event: MainThread.MouseEvent) => {
+    'main thread';
+    if (action === 'touchmove') {
+      const buttons = (event as unknown as { buttons?: number }).buttons;
+      // Allow only left-button drags
+      if (!buttons || (buttons & 1) === 0) return;
+    }
+    handler(toTouchEventMT(event, action));
+  };
+}
+
+function useTouchEmulation(
+  options: UseTouchEmulationOptions,
+): UseTouchEmulationReturn {
+  const dependencies = touchCallbackKeys.map((key) => options[key]);
   const result = useMemo<UseTouchEmulationReturn>(() => {
     const r: UseTouchEmulationReturn = {};
 
-    if (onTouchStart) {
-      r.bindtouchstart = (event: TouchEvent) => {
-        'background only';
-        onTouchStart(toTouchEvent(event, 'touchstart'));
-      };
-      r.bindmousedown = (event: MouseEvent) => {
-        'background only'
-        onTouchStart(toTouchEvent(event, 'touchstart'));
-      };
-    }
+    for (const mode of bindingModes) {
+      for (const action of touchActions) {
+        const callbackKey =
+          `${mode.callbackPrefix}Touch${action.name}` as TouchCallbackName;
+        const callbackMTKey =
+          `${mode.callbackPrefix}Touch${action.name}MT` as TouchCallbackName;
 
-    if (onTouchMove) {
-      r.bindtouchmove = (event: TouchEvent) => {
-        'background only';
-        onTouchMove(toTouchEvent(event, 'touchmove'));
-      };
-      r.bindmousemove = (event: MouseEvent) => {
-        'background only';
-        const buttons = (event as unknown as { buttons?: number }).buttons;
-        // Allow only left-button drags
-        if (!buttons || (buttons & 1) === 0) return;
-        onTouchMove(toTouchEvent(event, 'touchmove'));
-      };
-    }
-
-    if (onTouchEnd) {
-      r.bindtouchend = (event: TouchEvent) => {
-        'background only';
-        onTouchEnd(toTouchEvent(event, 'touchend'));
-      };
-      r.bindmouseup = (event: MouseEvent) => {
-        'background only';
-        onTouchEnd(toTouchEvent(event, 'touchend'));
-      };
-    }
-
-    if (onTouchCancel) {
-      r.bindtouchcancel = (event: TouchEvent) => {
-        'background only';
-        onTouchCancel(toTouchEvent(event, 'touchcancel'));
-      };
-    }
-
-    if (onTouchStartMT) {
-      r['main-thread:bindtouchstart'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onTouchStartMT(toTouchEventMT(event, 'touchstart'));
-      };
-
-      r['main-thread:bindmousedown'] = (event: MainThread.MouseEvent) => {
-        'main thread';
-        onTouchStartMT(toTouchEventMT(event, 'touchstart'));
-      };
-    }
-
-    if (onTouchMoveMT) {
-      r['main-thread:bindtouchmove'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onTouchMoveMT(toTouchEventMT(event, 'touchmove'));
-      };
-      r['main-thread:bindmousemove'] = (event: MainThread.MouseEvent) => {
-        'main thread';
-        const buttons = (event as unknown as { buttons?: number }).buttons;
-        // Allow only left-button drags
-        if (!buttons || (buttons & 1) === 0) return;
-        onTouchMoveMT(toTouchEventMT(event, 'touchmove'));
-      };
-    }
-
-    if (onTouchEndMT) {
-      r['main-thread:bindtouchend'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onTouchEndMT(toTouchEventMT(event, 'touchend'));
-      };
-      r['main-thread:bindmouseup'] = (event: MainThread.MouseEvent) => {
-        'main thread';
-        onTouchEndMT(toTouchEventMT(event, 'touchend'));
-      };
-    }
-
-    if (onTouchCancelMT) {
-      r['main-thread:bindtouchcancel'] = (event: MainThread.TouchEvent) => {
-        'main thread';
-        onTouchCancelMT(toTouchEventMT(event, 'touchcancel'));
-      };
+        addTouchHandler(
+          r,
+          mode.eventPrefix,
+          action.touchEvent,
+          action.mouseEvent,
+          action.action,
+          options[callbackKey] as ((event: TouchEvent) => void) | undefined,
+        );
+        addTouchHandlerMT(
+          r,
+          mode.eventPrefix,
+          action.touchEvent,
+          action.mouseEvent,
+          action.action,
+          options[callbackMTKey] as
+            | ((event: MainThread.TouchEvent) => void)
+            | undefined,
+        );
+      }
     }
 
     return r;
-  }, [
-    onTouchStart,
-    onTouchMove,
-    onTouchEnd,
-    onTouchCancel,
-    onTouchStartMT,
-    onTouchMoveMT,
-    onTouchEndMT,
-    onTouchCancelMT,
-  ]);
+  }, dependencies);
 
   return result;
 }

--- a/tests/usePointerEvent.test.tsx
+++ b/tests/usePointerEvent.test.tsx
@@ -10,6 +10,127 @@ import usePointerEvent, {
 } from '../src/usePointerEvent';
 
 describe('usePointerEvent (BT) integration', () => {
+  it('maps catch handlers separately from bind handlers', () => {
+    const catchPointerDown = vi.fn();
+    const catchPointerMove = vi.fn();
+    const catchPointerUp = vi.fn();
+    const catchPointerCancel = vi.fn();
+    let lastProps: ReturnType<typeof usePointerEvent> | undefined;
+    const Comp = () => {
+      lastProps = usePointerEvent({
+        onPointerDown: vi.fn(),
+        catchPointerDown,
+        catchPointerMove,
+        catchPointerUp,
+        catchPointerCancel,
+      });
+      return <view {...lastProps}></view>;
+    };
+    render(<Comp />);
+
+    expect(lastProps?.bindmousedown).toBeDefined();
+    expect(lastProps?.catchmousemove).toBeDefined();
+    expect(lastProps?.bindmousemove).toBeUndefined();
+
+    lastProps?.catchmousedown?.({
+      x: 10,
+      y: 20,
+      pageX: 110,
+      pageY: 120,
+      clientX: 210,
+      clientY: 220,
+      button: 1,
+      buttons: 3,
+    } as Parameters<NonNullable<typeof lastProps.catchmousedown>>[0]);
+    lastProps?.catchmousemove?.({
+      x: 11,
+      y: 21,
+      pageX: 111,
+      pageY: 121,
+    } as Parameters<NonNullable<typeof lastProps.catchmousemove>>[0]);
+    lastProps?.catchmouseup?.({
+      x: 12,
+      y: 22,
+      pageX: 112,
+      pageY: 122,
+    } as Parameters<NonNullable<typeof lastProps.catchmouseup>>[0]);
+    lastProps?.catchtouchcancel?.({
+      touches: [],
+      changedTouches: [{
+        identifier: 4,
+        pageX: 113,
+        pageY: 123,
+        clientX: 213,
+        clientY: 223,
+      }],
+    } as unknown as Parameters<NonNullable<typeof lastProps.catchtouchcancel>>[0]);
+
+    expect(catchPointerDown).toHaveBeenCalledTimes(1);
+    expect(catchPointerMove).toHaveBeenCalledTimes(1);
+    expect(catchPointerUp).toHaveBeenCalledTimes(1);
+    expect(catchPointerCancel).toHaveBeenCalledTimes(1);
+    expect(catchPointerDown.mock.calls[0][0]).toMatchObject({
+      type: 'pointerdown',
+      pointerType: 'mouse',
+      button: 0,
+      buttons: 3,
+      x: 10,
+    });
+    expect(catchPointerCancel.mock.calls[0][0]).toMatchObject({
+      type: 'pointercancel',
+      pointerType: 'touch',
+      pointerId: 4,
+    });
+  });
+
+  it('maps capture handlers separately from bind and catch handlers', () => {
+    const captureBindPointerDown = vi.fn();
+    const captureCatchPointerMove = vi.fn();
+    let lastProps: ReturnType<typeof usePointerEvent> | undefined;
+    const Comp = () => {
+      lastProps = usePointerEvent({
+        captureBindPointerDown,
+        captureCatchPointerMove,
+      });
+      return <view {...lastProps}></view>;
+    };
+    render(<Comp />);
+
+    expect(lastProps?.['capture-bindmousedown']).toBeDefined();
+    expect(lastProps?.['capture-bindtouchstart']).toBeDefined();
+    expect(lastProps?.['capture-catchmousemove']).toBeDefined();
+    expect(lastProps?.['capture-catchtouchmove']).toBeDefined();
+    expect(lastProps?.bindmousedown).toBeUndefined();
+    expect(lastProps?.catchmousemove).toBeUndefined();
+
+    lastProps?.['capture-bindmousedown']?.({
+      x: 10,
+      y: 20,
+      pageX: 110,
+      pageY: 120,
+      clientX: 210,
+      clientY: 220,
+      button: 1,
+      buttons: 3,
+    } as Parameters<NonNullable<typeof lastProps['capture-bindmousedown']>>[0]);
+    lastProps?.['capture-catchmousemove']?.({
+      x: 11,
+      y: 21,
+      pageX: 111,
+      pageY: 121,
+    } as Parameters<NonNullable<typeof lastProps['capture-catchmousemove']>>[0]);
+
+    expect(captureBindPointerDown).toHaveBeenCalledTimes(1);
+    expect(captureCatchPointerMove).toHaveBeenCalledTimes(1);
+    expect(captureBindPointerDown.mock.calls[0][0]).toMatchObject({
+      type: 'pointerdown',
+      pointerType: 'mouse',
+      button: 0,
+      buttons: 3,
+      x: 10,
+    });
+  });
+
   it('binds mouse down and normalizes button/buttons', () => {
     const onPointerDown = vi.fn();
     const Comp = () => {
@@ -68,6 +189,58 @@ describe('usePointerEvent (BT) integration', () => {
 });
 
 describe('usePointerEvent (MT) integration', () => {
+  it('maps main-thread catch handlers separately from bind handlers', () => {
+    const Comp = () => {
+      const props = usePointerEvent({
+        onPointerDownMT: () => {
+          'main thread';
+        },
+        catchPointerMoveMT: () => {
+          'main thread';
+        },
+        catchPointerUpMT: () => {
+          'main thread';
+        },
+        catchPointerCancelMT: () => {
+          'main thread';
+        },
+      });
+
+      expect(props['main-thread:bindmousedown']).toBeDefined();
+      expect(props['main-thread:catchmousedown']).toBeUndefined();
+      expect(props['main-thread:bindmousemove']).toBeUndefined();
+      expect(props['main-thread:catchmousemove']).toBeDefined();
+      expect(props['main-thread:catchtouchmove']).toBeDefined();
+      expect(props['main-thread:catchtouchcancel']).toBeDefined();
+      return <view {...props}></view>;
+    };
+
+    render(<Comp />);
+  });
+
+  it('maps main-thread capture handlers separately', () => {
+    const Comp = () => {
+      const props = usePointerEvent({
+        captureBindPointerDownMT: () => {
+          'main thread';
+        },
+        captureCatchPointerMoveMT: () => {
+          'main thread';
+        },
+      });
+
+      expect(props['main-thread:capture-bindmousedown']).toBeDefined();
+      expect(props['main-thread:capture-bindtouchstart']).toBeDefined();
+      expect(props['main-thread:capture-catchmousemove']).toBeDefined();
+      expect(props['main-thread:capture-catchtouchmove']).toBeDefined();
+      expect(props['main-thread:bindmousedown']).toBeUndefined();
+      expect(props['main-thread:catchmousemove']).toBeUndefined();
+      return <view {...props}></view>;
+    };
+
+    render(<Comp />);
+  });
+
   it('binds MT mouse down and normalizes button/buttons/targets', async () => {
     let mtEventRef: MainThreadRef<CustomPointerEventMT | null>;
     const Comp = () => {

--- a/tests/useTouchEmulation.test.tsx
+++ b/tests/useTouchEmulation.test.tsx
@@ -9,6 +9,110 @@ import { describe, expect, it, vi } from 'vitest';
 import useTouchEmulation from '../src/useTouchEmulation';
 
 describe('useTouchEmulation (BT) integration', () => {
+  it('maps catch handlers separately from bind handlers', () => {
+    const catchTouchStart = vi.fn();
+    const catchTouchMove = vi.fn();
+    const catchTouchEnd = vi.fn();
+    const catchTouchCancel = vi.fn();
+    let lastProps: ReturnType<typeof useTouchEmulation> | undefined;
+    const Comp = () => {
+      lastProps = useTouchEmulation({
+        onTouchStart: vi.fn(),
+        catchTouchStart,
+        catchTouchMove,
+        catchTouchEnd,
+        catchTouchCancel,
+      });
+      return <view {...lastProps}></view>;
+    };
+    render(<Comp />);
+
+    expect(lastProps?.bindtouchstart).toBeDefined();
+    expect(lastProps?.catchtouchmove).toBeDefined();
+    expect(lastProps?.bindtouchmove).toBeUndefined();
+
+    lastProps?.catchmousedown?.({
+      pageX: 110,
+      pageY: 120,
+      clientX: 210,
+      clientY: 220,
+    } as Parameters<NonNullable<typeof lastProps.catchmousedown>>[0]);
+    lastProps?.catchmousemove?.({
+      pageX: 115,
+      pageY: 125,
+      clientX: 215,
+      clientY: 225,
+      buttons: 1,
+    } as Parameters<NonNullable<typeof lastProps.catchmousemove>>[0]);
+    lastProps?.catchmouseup?.({
+      pageX: 116,
+      pageY: 126,
+      clientX: 216,
+      clientY: 226,
+    } as Parameters<NonNullable<typeof lastProps.catchmouseup>>[0]);
+    lastProps?.catchtouchcancel?.({
+      touches: [],
+      changedTouches: [{
+        identifier: 1,
+        pageX: 117,
+        pageY: 127,
+        clientX: 217,
+        clientY: 227,
+      }],
+    } as unknown as Parameters<NonNullable<typeof lastProps.catchtouchcancel>>[0]);
+
+    expect(catchTouchStart).toHaveBeenCalledTimes(1);
+    expect(catchTouchMove).toHaveBeenCalledTimes(1);
+    expect(catchTouchEnd).toHaveBeenCalledTimes(1);
+    expect(catchTouchCancel).toHaveBeenCalledTimes(1);
+    const startEvent = catchTouchStart.mock.calls[0][0] as unknown as TouchEvent;
+    // @ts-expect-error test environment type narrowing
+    expect(startEvent.detail.x).toBe(110);
+    expect(startEvent.touches[0].clientX).toBe(210);
+  });
+
+  it('maps capture handlers separately from bind and catch handlers', () => {
+    const captureBindTouchStart = vi.fn();
+    const captureCatchTouchMove = vi.fn();
+    let lastProps: ReturnType<typeof useTouchEmulation> | undefined;
+    const Comp = () => {
+      lastProps = useTouchEmulation({
+        captureBindTouchStart,
+        captureCatchTouchMove,
+      });
+      return <view {...lastProps}></view>;
+    };
+    render(<Comp />);
+
+    expect(lastProps?.['capture-bindtouchstart']).toBeDefined();
+    expect(lastProps?.['capture-bindmousedown']).toBeDefined();
+    expect(lastProps?.['capture-catchtouchmove']).toBeDefined();
+    expect(lastProps?.['capture-catchmousemove']).toBeDefined();
+    expect(lastProps?.bindtouchstart).toBeUndefined();
+    expect(lastProps?.catchtouchmove).toBeUndefined();
+
+    lastProps?.['capture-bindmousedown']?.({
+      pageX: 110,
+      pageY: 120,
+      clientX: 210,
+      clientY: 220,
+    } as Parameters<NonNullable<typeof lastProps['capture-bindmousedown']>>[0]);
+    lastProps?.['capture-catchmousemove']?.({
+      pageX: 115,
+      pageY: 125,
+      clientX: 215,
+      clientY: 225,
+      buttons: 1,
+    } as Parameters<NonNullable<typeof lastProps['capture-catchmousemove']>>[0]);
+
+    expect(captureBindTouchStart).toHaveBeenCalledTimes(1);
+    expect(captureCatchTouchMove).toHaveBeenCalledTimes(1);
+    const startEvent = captureBindTouchStart.mock.calls[0][0] as unknown as TouchEvent;
+    // @ts-expect-error test environment type narrowing
+    expect(startEvent.detail.x).toBe(110);
+    expect(startEvent.touches[0].clientX).toBe(210);
+  });
+
   it('synthesizes touch from mouse down', () => {
     const onTouchStart = vi.fn();
     const Comp = () => {
@@ -212,6 +316,58 @@ describe('useTouchEmulation event semantics', () => {
   });
 });
 describe('useTouchEmulation (MT) integration', () => {
+  it('maps main-thread catch handlers separately from bind handlers', () => {
+    const Comp = () => {
+      const props = useTouchEmulation({
+        onTouchStartMT: () => {
+          'main thread';
+        },
+        catchTouchMoveMT: () => {
+          'main thread';
+        },
+        catchTouchEndMT: () => {
+          'main thread';
+        },
+        catchTouchCancelMT: () => {
+          'main thread';
+        },
+      });
+
+      expect(props['main-thread:bindtouchstart']).toBeDefined();
+      expect(props['main-thread:catchtouchstart']).toBeUndefined();
+      expect(props['main-thread:bindtouchmove']).toBeUndefined();
+      expect(props['main-thread:catchtouchmove']).toBeDefined();
+      expect(props['main-thread:catchmousemove']).toBeDefined();
+      expect(props['main-thread:catchtouchcancel']).toBeDefined();
+      return <view {...props}></view>;
+    };
+
+    render(<Comp />);
+  });
+
+  it('maps main-thread capture handlers separately', () => {
+    const Comp = () => {
+      const props = useTouchEmulation({
+        captureBindTouchStartMT: () => {
+          'main thread';
+        },
+        captureCatchTouchMoveMT: () => {
+          'main thread';
+        },
+      });
+
+      expect(props['main-thread:capture-bindtouchstart']).toBeDefined();
+      expect(props['main-thread:capture-bindmousedown']).toBeDefined();
+      expect(props['main-thread:capture-catchtouchmove']).toBeDefined();
+      expect(props['main-thread:capture-catchmousemove']).toBeDefined();
+      expect(props['main-thread:bindtouchstart']).toBeUndefined();
+      expect(props['main-thread:catchtouchmove']).toBeUndefined();
+      return <view {...props}></view>;
+    };
+
+    render(<Comp />);
+  });
+
   it('synthesizes MT touch from mouse down', async () => {
     let mtEventRef: MainThreadRef<MainThread.TouchEvent | null>;
     const Comp = () => {


### PR DESCRIPTION
Update `useTouchEmulation` and `usePointerEvent` to make them support `bind`, `catch`, `captureBind`, `captureCatch` event