### PR TITLE
fix: preserve ESM module boundaries

### DIFF
--- a/.changeset/clean-cats-shake.md
+++ b/.changeset/clean-cats-shake.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-use": patch
+---
+
+Preserve ESM module boundaries so root imports can tree-shake unused hooks.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "docs:deploy": "RSPRESS_DEPLOY=1 rspress build",
     "docs:preview": "rspress preview",
     "format": "biome format --write",
-    "test": "vitest",
+    "test": "vitest && pnpm test:tree-shaking",
+    "test:tree-shaking": "pnpm build && node scripts/test-tree-shaking.mjs",
     "release": "pnpm run build && pnpm changeset publish",
     "prepare": "husky"
   },

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     {
       format: "esm",
       syntax: "es2022",
+      bundle: false,
       dts: true,
     },
     {

--- a/scripts/test-tree-shaking.mjs
+++ b/scripts/test-tree-shaking.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { rspack } from "@rslib/core";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+await access(path.join(packageRoot, "dist/useTouchEmulation.js"));
+
+const temporaryRoot = await mkdtemp(
+  path.join(tmpdir(), "reactlynx-use-tree-shaking-"),
+);
+
+try {
+  const entryPath = path.join(temporaryRoot, "index.js");
+  const outputPath = path.join(temporaryRoot, "dist");
+
+  await writeFile(
+    entryPath,
+    [
+      'import { useTouchEmulation } from "@lynx-js/react-use";',
+      "globalThis.__useTouchEmulation = useTouchEmulation;",
+    ].join("\n"),
+  );
+
+  const compiler = rspack({
+    mode: "production",
+    entry: entryPath,
+    externals: {
+      "@lynx-js/react": "@lynx-js/react",
+    },
+    externalsType: "commonjs",
+    output: {
+      clean: true,
+      filename: "bundle.js",
+      path: outputPath,
+    },
+    optimization: {
+      minimize: false,
+    },
+    resolve: {
+      alias: {
+        "@lynx-js/react-use$": path.join(packageRoot, "dist/index.js"),
+      },
+    },
+  });
+
+  try {
+    const stats = await new Promise((resolve, reject) => {
+      compiler.run((error, result) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (result?.hasErrors()) {
+          reject(new Error(result.toString({ all: false, errors: true })));
+          return;
+        }
+        resolve(result);
+      });
+    });
+
+    assert.ok(stats);
+
+    const bundle = await readFile(path.join(outputPath, "bundle.js"), "utf8");
+    assert.match(bundle, /useTouchEmulation/);
+    assert.doesNotMatch(bundle, /useExposureForNode/);
+    assert.doesNotMatch(bundle, /useExposureForPage/);
+    assert.doesNotMatch(bundle, /useStayTime/);
+    assert.doesNotMatch(bundle, /createKeyedAdmissionGate/);
+    assert.doesNotMatch(bundle, /react-use\/esm/);
+    assert.doesNotMatch(bundle, /nanoid|immer/);
+  } finally {
+    await new Promise((resolve, reject) => {
+      compiler.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+} finally {
+  await rm(temporaryRoot, { force: true, recursive: true });
+}

--- a/src/react-use.ts
+++ b/src/react-use.ts
@@ -30,28 +30,34 @@ import { default as _useUnmount } from "./useUnmount.js";
 import { default as _useUnmountPromise } from "./useUnmountPromise.js";
 import { default as _useUpdateEffect } from "./useUpdateEffect.js";
 
-export const createMemo = factory(_createMemo);
-export const useBoolean = factory(_useBoolean);
-export const useCounter = factory(_useCounter);
-export const useDefault = factory(_useDefault);
-export const useEffectOnce = factory(_useEffectOnce);
-export const useError = factory(_useError);
-export const useLatest = factory(_useLatest);
-export const useLifecycles = factory(_useLifecycles);
-export const useMap = factory(_useMap);
-export const useMountedState = factory(_useMountedState);
-export const useNumber = factory(_useNumber);
-export const usePrevious = factory(_usePrevious);
-export const useQueue = factory(_useQueue);
-export const useSet = factory(_useSet);
-export const useSetState = factory(_useSetState);
-export const useThrottle = factory(_useThrottle);
-export const useThrottleFn = factory(_useThrottleFn);
-export const useToggle = factory(_useToggle);
-export const useUnmount = factory(_useUnmount);
-export const useUnmountPromise = factory(_useUnmountPromise);
-export const useUpdateEffect = factory(_useUpdateEffect);
-export const useExposureForNode = factory(_useExposureForNode);
-export const useExposureForPage = factory(_useExposureForPage);
-export const useListScrollEvent = factory(_useListScrollEvent);
-export const useStayTime = factory(_useStayTime);
+export const createMemo = /* @__PURE__ */ factory(_createMemo);
+export const useBoolean = /* @__PURE__ */ factory(_useBoolean);
+export const useCounter = /* @__PURE__ */ factory(_useCounter);
+export const useDefault = /* @__PURE__ */ factory(_useDefault);
+export const useEffectOnce = /* @__PURE__ */ factory(_useEffectOnce);
+export const useError = /* @__PURE__ */ factory(_useError);
+export const useLatest = /* @__PURE__ */ factory(_useLatest);
+export const useLifecycles = /* @__PURE__ */ factory(_useLifecycles);
+export const useMap = /* @__PURE__ */ factory(_useMap);
+export const useMountedState = /* @__PURE__ */ factory(_useMountedState);
+export const useNumber = /* @__PURE__ */ factory(_useNumber);
+export const usePrevious = /* @__PURE__ */ factory(_usePrevious);
+export const useQueue = /* @__PURE__ */ factory(_useQueue);
+export const useSet = /* @__PURE__ */ factory(_useSet);
+export const useSetState = /* @__PURE__ */ factory(_useSetState);
+export const useThrottle = /* @__PURE__ */ factory(_useThrottle);
+export const useThrottleFn = /* @__PURE__ */ factory(_useThrottleFn);
+export const useToggle = /* @__PURE__ */ factory(_useToggle);
+export const useUnmount = /* @__PURE__ */ factory(_useUnmount);
+export const useUnmountPromise = /* @__PURE__ */ factory(_useUnmountPromise);
+export const useUpdateEffect = /* @__PURE__ */ factory(_useUpdateEffect);
+export const useExposureForNode = /* @__PURE__ */ factory(
+  _useExposureForNode,
+);
+export const useExposureForPage = /* @__PURE__ */ factory(
+  _useExposureForPage,
+);
+export const useListScrollEvent = /* @__PURE__ */ factory(
+  _useListScrollEvent,
+);
+export const useStayTime = /* @__PURE__ */ factory(_useStayTime);


### PR DESCRIPTION
Publish ESM output with per-hook module boundaries so root imports can tree-shake unrelated hooks while preserving the existing API.

Keep CJS output bundled for compatibility and mark background-only wrapper initialization as pure.

Closes #56