### PR TITLE
fix(ci): pin npm 11 for changesets publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          npm i -g corepack npm@latest
+          # Changesets still passes --no-git-checks to npm publish, which npm 12 removed.
+          npm i -g corepack npm@11.18.0
           npm --version
           corepack enable
           pnpm install


### PR DESCRIPTION
Pin the release workflow to npm 11.18.0 so Changesets can continue publishing through npm trusted publishing after npm 12 removed the git-checks option.