### PR TITLE
fix: publish ESM-only package

### DIFF
--- a/.changeset/bright-lynxes-import.md
+++ b/.changeset/bright-lynxes-import.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-use": patch
+---
+
+Publish an ESM-only package and remove the CommonJS entry point.

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -9,10 +9,6 @@ export default defineConfig({
       bundle: false,
       dts: true,
     },
-    {
-      format: "cjs",
-      syntax: ["node 18"],
-    },
   ],
   source: {
     tsconfigPath: "./tsconfig.build.json",

--- a/scripts/test-tree-shaking.mjs
+++ b/scripts/test-tree-shaking.mjs
@@ -11,6 +11,9 @@ const packageRoot = path.resolve(
   "..",
 );
 await access(path.join(packageRoot, "dist/useTouchEmulation.js"));
+await assert.rejects(access(path.join(packageRoot, "dist/index.cjs")), {
+  code: "ENOENT",
+});
 
 const temporaryRoot = await mkdtemp(
   path.join(tmpdir(), "reactlynx-use-tree-shaking-"),
@@ -45,7 +48,7 @@ try {
     },
     resolve: {
       alias: {
-        "@lynx-js/react-use$": path.join(packageRoot, "dist/index.js"),
+        "@lynx-js/react-use$": packageRoot,
       },
     },
   });


### PR DESCRIPTION
Publish @lynx-js/react-use as a bundleless ESM-only package for Rspeedy/Rspack consumers. Remove the CommonJS build and export, point the package entry to the ESM artifact, and make the tree-shaking coverage resolve through the public package exports. This also removes the dual-package declaration warning.