### PR TITLE
feat: add useComputedStyle hook

### DIFF
--- a/docs/en/mts/README.md
+++ b/docs/en/mts/README.md
@@ -1,3 +1,5 @@
 # Main Thread Script (MTS)
 
 _"MTS Hooks"_ unleash the power of Lynx's [Main Thread Script](https://lynxjs.org/next/react/main-thread-script.html).
+
+- [useComputedStyle](./useComputedStyle) — Read resolved computed CSS property values from a main-thread element.

--- a/docs/en/mts/useComputedStyle.md
+++ b/docs/en/mts/useComputedStyle.md
@@ -1,0 +1,99 @@
+# useComputedStyle
+
+A Hook that reads resolved computed CSS property values from a main-thread element and forwards them to the background (React) thread.
+
+## Problem
+
+Lynx's `<svg>` element has a `current-color` prop (and `<image>` has `tint-color`) that accepts a plain color string, but **does not support `var(--css-var)` syntax** because it's a component prop, not a CSS property.
+
+This makes it hard to drive SVG icon colors from CSS custom properties — a common pattern in design systems that use CSS variables for theming.
+
+## Solution
+
+`useComputedStyle` bridges the gap:
+
+1. Declare a standard CSS property with a `var()` value (e.g. `color: var(--theme-icon-color)`)
+2. The hook reads the **resolved** value on the main thread via `element.getComputedStyles()`
+3. The resolved value is forwarded to the background thread via `runOnBackground`
+4. Use the resolved value in JSX props that only accept plain strings
+
+## Usage
+
+```tsx
+import { useComputedStyle } from "@lynx-js/react-use";
+
+function MonochromeIcon({ src }: { src: string }) {
+  const [ref, { color }] = useComputedStyle(["color"]);
+  return (
+    <view main-thread:ref={ref} className="icon">
+      <svg src={src} current-color={color} />
+    </view>
+  );
+}
+```
+
+```css
+.icon {
+  color: var(--theme-icon-color);
+}
+```
+
+## Theme Switching Example
+
+```tsx
+import { useState } from "@lynx-js/react";
+import { useComputedStyle } from "@lynx-js/react-use";
+
+function ThemedIcon({ src }: { src: string }) {
+  const [dark, setDark] = useState(false);
+  const [ref, { color }] = useComputedStyle(["color"]);
+
+  return (
+    <view className={dark ? "theme-dark" : "theme-light"}>
+      <view main-thread:ref={ref} className="icon">
+        <svg src={src} current-color={color} />
+      </view>
+      <view bindtap={() => setDark(!dark)}>
+        <text>Toggle Theme</text>
+      </view>
+    </view>
+  );
+}
+```
+
+```css
+.theme-light {
+  --theme-icon-color: #1a1a1a;
+}
+.theme-dark {
+  --theme-icon-color: #ffffff;
+}
+.icon {
+  color: var(--theme-icon-color);
+}
+```
+
+## Reading Multiple Properties
+
+```tsx
+const [ref, styles] = useComputedStyle(["color", "background-color", "opacity"]);
+// styles.color, styles['background-color'], styles.opacity
+```
+
+## Limitations
+
+- The `keys` array is captured by the worklet closure at creation time. If you need to change which properties are read, the component must remount.
+- The resolved values are delivered asynchronously (one main-thread → background-thread round trip), so there may be a single frame where `styles` is empty `{}`.
+
+## Type Declarations
+
+```ts
+import type { MainThread } from "@lynx-js/types";
+
+type UseComputedStyleReturn = [
+  ref: (element: MainThread.Element | null) => void,
+  styles: Record<string, string>,
+];
+
+function useComputedStyle(keys: string[]): UseComputedStyleReturn;
+```

--- a/docs/en/mts/useComputedStyle.md
+++ b/docs/en/mts/useComputedStyle.md
@@ -85,6 +85,121 @@ const [ref, styles] = useComputedStyle(["color", "background-color", "opacity"])
 - The `keys` array is captured by the worklet closure at creation time. If you need to change which properties are read, the component must remount.
 - The resolved values are delivered asynchronously (one main-thread → background-thread round trip), so there may be a single frame where `styles` is empty `{}`.
 
+## Full Working Example: CSS Vars → SVG Color Polyfill
+
+This example demonstrates a complete theme-switching UI where CSS custom properties drive SVG icon colors via `useComputedStyle`.
+
+```tsx
+// src/App.tsx
+import { useCallback, useState } from "@lynx-js/react";
+import { useComputedStyle } from "@lynx-js/react-use";
+import "./App.css";
+
+const PLAY_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" fill="currentColor"/></svg>`;
+
+const THEMES = [
+  { name: "Blue", color: "#1a73e8" },
+  { name: "Red", color: "#d93025" },
+  { name: "Green", color: "#1e8e3e" },
+  { name: "Orange", color: "#f29900" },
+];
+
+function ThemedIcon() {
+  const [ref, styles] = useComputedStyle(["color"]);
+  const currentColor = styles["color"] || "#1a73e8";
+
+  return (
+    <view className="icon-wrapper" main-thread:ref={ref}>
+      <svg content={PLAY_ICON_SVG} current-color={currentColor} />
+    </view>
+  );
+}
+
+export function App() {
+  const [themeIndex, setThemeIndex] = useState(0);
+  const theme = THEMES[themeIndex];
+
+  const switchTheme = useCallback((i: number) => {
+    "background only";
+    setThemeIndex(i);
+  }, []);
+
+  return (
+    <view className="container">
+      <text className="title">useComputedStyle + SVG</text>
+      <text className="subtitle">CSS vars → SVG current-color polyfill</text>
+
+      {/* CSS `color` on this container drives the SVG fill via the hook */}
+      <view className="icon-container" style={{ color: theme.color }}>
+        <ThemedIcon />
+      </view>
+
+      <text className="theme-label" style={{ color: theme.color }}>
+        {theme.name} Theme
+      </text>
+
+      <view className="button-row">
+        {THEMES.map((t, i) => (
+          <view
+            key={t.name}
+            bindtap={() => switchTheme(i)}
+            className="theme-btn"
+            style={{
+              backgroundColor: i === themeIndex ? t.color : "#ffffff",
+              borderColor: t.color,
+            }}
+          >
+            <text
+              className="theme-btn-text"
+              style={{ color: i === themeIndex ? "#ffffff" : t.color }}
+            >
+              {t.name}
+            </text>
+          </view>
+        ))}
+      </view>
+    </view>
+  );
+}
+```
+
+```css
+/* src/App.css */
+.container {
+  width: 100vw;
+  min-height: 100vh;
+  background-color: #f8f9fa;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 80rpx;
+}
+
+.icon-container {
+  color: var(--theme-color);
+  width: 200rpx;
+  height: 200rpx;
+  border-radius: 100rpx;
+  background-color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 60rpx;
+}
+
+.icon-wrapper {
+  width: 120rpx;
+  height: 120rpx;
+}
+```
+
+### How It Works
+
+1. The parent `<view className="icon-container">` sets `color` via inline style (which could also be `color: var(--theme-color)` in CSS).
+2. `useComputedStyle(['color'])` reads the resolved `color` value from the main thread element.
+3. The resolved color string is forwarded to the background thread via `runOnBackground`.
+4. The `<svg>` element receives the color through its `current-color` prop — bypassing the limitation that props can't use `var()` directly.
+
 ## Type Declarations
 
 ```ts

--- a/docs/zh/mts/README.md
+++ b/docs/zh/mts/README.md
@@ -1,3 +1,5 @@
 # Main Thread Script (MTS)
 
 _"MTS Hooks"_ unleash the power of Lynx's [Main Thread Script](https://lynxjs.org/next/react/main-thread-script.html).
+
+- [useComputedStyle](./useComputedStyle) — 从主线程元素读取已解析的 CSS 计算属性值。

--- a/docs/zh/mts/useComputedStyle.md
+++ b/docs/zh/mts/useComputedStyle.md
@@ -1,0 +1,99 @@
+# useComputedStyle
+
+从主线程元素读取已解析的 CSS 计算属性值，并将其转发到后台（React）线程的 Hook。
+
+## 问题
+
+Lynx 的 `<svg>` 元素有一个 `current-color` 属性（`<image>` 有 `tint-color`），它接受纯色字符串，但**不支持 `var(--css-var)` 语法**，因为它是组件属性而非 CSS 属性。
+
+这使得通过 CSS 自定义属性驱动 SVG 图标颜色变得困难——而这在使用 CSS 变量进行主题化的设计系统中是一种常见模式。
+
+## 解决方案
+
+`useComputedStyle` 弥补了这一差距：
+
+1. 声明一个带 `var()` 值的标准 CSS 属性（如 `color: var(--theme-icon-color)`）
+2. Hook 通过 `element.getComputedStyles()` 在主线程上读取**已解析的**值
+3. 通过 `runOnBackground` 将已解析的值转发到后台线程
+4. 在仅接受纯字符串的 JSX 属性中使用已解析的值
+
+## 用法
+
+```tsx
+import { useComputedStyle } from "@lynx-js/react-use";
+
+function MonochromeIcon({ src }: { src: string }) {
+  const [ref, { color }] = useComputedStyle(["color"]);
+  return (
+    <view main-thread:ref={ref} className="icon">
+      <svg src={src} current-color={color} />
+    </view>
+  );
+}
+```
+
+```css
+.icon {
+  color: var(--theme-icon-color);
+}
+```
+
+## 主题切换示例
+
+```tsx
+import { useState } from "@lynx-js/react";
+import { useComputedStyle } from "@lynx-js/react-use";
+
+function ThemedIcon({ src }: { src: string }) {
+  const [dark, setDark] = useState(false);
+  const [ref, { color }] = useComputedStyle(["color"]);
+
+  return (
+    <view className={dark ? "theme-dark" : "theme-light"}>
+      <view main-thread:ref={ref} className="icon">
+        <svg src={src} current-color={color} />
+      </view>
+      <view bindtap={() => setDark(!dark)}>
+        <text>切换主题</text>
+      </view>
+    </view>
+  );
+}
+```
+
+```css
+.theme-light {
+  --theme-icon-color: #1a1a1a;
+}
+.theme-dark {
+  --theme-icon-color: #ffffff;
+}
+.icon {
+  color: var(--theme-icon-color);
+}
+```
+
+## 读取多个属性
+
+```tsx
+const [ref, styles] = useComputedStyle(["color", "background-color", "opacity"]);
+// styles.color, styles['background-color'], styles.opacity
+```
+
+## 限制
+
+- `keys` 数组在 worklet 闭包创建时被捕获。如果需要更改读取的属性，组件必须重新挂载。
+- 已解析的值是异步传递的（一次主线程 → 后台线程的往返），因此可能存在单帧 `styles` 为空 `{}` 的情况。
+
+## 类型声明
+
+```ts
+import type { MainThread } from "@lynx-js/types";
+
+type UseComputedStyleReturn = [
+  ref: (element: MainThread.Element | null) => void,
+  styles: Record<string, string>,
+];
+
+function useComputedStyle(keys: string[]): UseComputedStyleReturn;
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ export type {
   StateFromFunctionReturningPromise,
 } from "./useAsyncFn.js";
 export { default as useAsyncFn } from './useAsyncFn.js';
+export type { UseComputedStyleReturn } from './useComputedStyle.js';
+export { default as useComputedStyle } from './useComputedStyle.js';
 export { default as useDebounce } from './useDebounce.js';
 export { default as useEventListener } from './useEventListener.js';
 export type { DraftFunction, ImmerHook, Updater } from './useImmer.js';

--- a/src/useComputedStyle.ts
+++ b/src/useComputedStyle.ts
@@ -1,0 +1,61 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { runOnBackground, useState } from '@lynx-js/react';
+import type { MainThread } from '@lynx-js/types';
+
+interface MainThreadElementWithComputedStyles extends MainThread.Element {
+  getComputedStyles(keys: string[]): Record<string, string>;
+}
+
+export type UseComputedStyleReturn = [
+  ref: (element: MainThread.Element | null) => void,
+  styles: Record<string, string>,
+];
+
+/**
+ * Reads resolved computed CSS property values from a main-thread element.
+ *
+ * CSS `var()` references are resolved in the styling pipeline, but some element
+ * props (e.g. `current-color` on `<svg>`, `tint-color` on `<image>`) cannot
+ * accept `var(...)` directly. This hook bridges the gap: declare a standard CSS
+ * property with a `var()` value, read the resolved value on the main thread,
+ * and forward it to the background (React) thread for use in JSX.
+ *
+ * @param keys - CSS property names in kebab-case to read.
+ * @returns A tuple of `[ref, styles]` where `ref` is a main-thread ref callback
+ *   and `styles` is the resolved values keyed by property name.
+ *
+ * @example
+ * ```tsx
+ * // .icon { color: var(--theme-icon-color); }
+ * const [ref, { color }] = useComputedStyle(['color']);
+ * return (
+ *   <view main-thread:ref={ref} className="icon">
+ *     <svg src={iconSrc} current-color={color} />
+ *   </view>
+ * );
+ * ```
+ */
+export default function useComputedStyle(keys: string[]): UseComputedStyleReturn {
+  const [styles, setStyles] = useState<Record<string, string>>({});
+
+  const sendToBackground = runOnBackground(
+    (resolved: Record<string, string>) => {
+      'background only';
+      setStyles(resolved);
+    },
+  );
+
+  const mtRef = (element: MainThread.Element | null) => {
+    'main thread';
+    if (!element) return;
+    const el = element as MainThreadElementWithComputedStyles;
+    if (typeof el.getComputedStyles !== 'function') return;
+    const resolved = el.getComputedStyles(keys);
+    sendToBackground(resolved);
+  };
+
+  return [mtRef, styles];
+}


### PR DESCRIPTION
## Summary

- Adds `useComputedStyle(keys)` — a main-thread hook that reads resolved computed CSS property values from an element and forwards them to the React background thread.
- Solves the gap where CSS `var()` references cannot be used directly in component props like `current-color` (on `<svg>`) or `tint-color` (on `<image>`).
- Uses `element.getComputedStyles()` (already available in Lynx's C++ layer) + `runOnBackground` to bridge the result to React state.

## Motivation

Design systems use CSS custom properties for theming. On the web, SVG icons are colored with `currentColor`. In Lynx, the equivalent `current-color` prop accepts only a plain string. This hook enables the same pattern:

```tsx
// CSS: .icon { color: var(--seed-color-fg-brand); }
const [ref, { color }] = useComputedStyle(['color']);
return (
  <view main-thread:ref={ref} className="icon">
    <svg src={iconSrc} current-color={color} />
  </view>
);
```

## Example: CSS Vars → SVG Color Polyfill

A complete theme-switching example is included in the docs (`docs/en/mts/useComputedStyle.md`). Here's the key pattern:

```tsx
import { useCallback, useState } from '@lynx-js/react';
import { useComputedStyle } from '@lynx-js/react-use';

const PLAY_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" fill="currentColor"/>
</svg>`;

const THEMES = [
  { name: 'Blue', color: '#1a73e8' },
  { name: 'Red', color: '#d93025' },
  { name: 'Green', color: '#1e8e3e' },
  { name: 'Orange', color: '#f29900' },
];

function ThemedIcon() {
  const [ref, styles] = useComputedStyle(['color']);
  const currentColor = styles['color'] || '#1a73e8';

  return (
    <view className="icon-wrapper" main-thread:ref={ref}>
      <svg content={PLAY_ICON_SVG} current-color={currentColor} />
    </view>
  );
}

export function App() {
  const [themeIndex, setThemeIndex] = useState(0);
  const theme = THEMES[themeIndex];

  const switchTheme = useCallback((i: number) => {
    'background only';
    setThemeIndex(i);
  }, []);

  return (
    <view className="container">
      {/* CSS `color` on this container drives the SVG fill via the hook */}
      <view className="icon-container" style={{ color: theme.color }}>
        <ThemedIcon />
      </view>

      <view className="button-row">
        {THEMES.map((t, i) => (
          <view key={t.name} bindtap={() => switchTheme(i)} className="theme-btn"
            style={{ backgroundColor: i === themeIndex ? t.color : '#ffffff', borderColor: t.color }}>
            <text style={{ color: i === themeIndex ? '#ffffff' : t.color }}>{t.name}</text>
          </view>
        ))}
      </view>
    </view>
  );
}
```

### How It Works

1. The parent view sets `color` (could be via inline style or `color: var(--theme-color)` in CSS).
2. `useComputedStyle(['color'])` reads the resolved value on the main thread.
3. The resolved value is forwarded to the background thread via `runOnBackground`.
4. The `<svg>` receives the color through its `current-color` prop — bypassing the `var()` limitation.

## Test Plan

- [x] Build succeeds (`pnpm build`)
- [x] Existing tests pass (`pnpm test`)
- [x] Tree-shaking test passes (`pnpm test:tree-shaking`)
- [x] Example project builds successfully with `rspeedy build`
- [x] Documentation with full working example added to `docs/en/mts/useComputedStyle.md`